### PR TITLE
Make <snapd-glib/snapd-glib.h> include snapd-enum-types.h

### DIFF
--- a/snapd-glib/snapd-glib.h
+++ b/snapd-glib/snapd-glib.h
@@ -18,6 +18,7 @@
 #include <snapd-glib/snapd-auth-data.h>
 #include <snapd-glib/snapd-client.h>
 #include <snapd-glib/snapd-connection.h>
+#include <snapd-glib/snapd-enum-types.h>
 #include <snapd-glib/snapd-error.h>
 #include <snapd-glib/snapd-icon.h>
 #include <snapd-glib/snapd-login.h>


### PR DESCRIPTION
The <snapd-glib/snapd-enum-types.h> header has guards to prevent it being included outside of <snapd-glib/snapd-glib.h>.  However, that header doesn't actually include it for you.