### PR TITLE
Only iterate our own GMainContext

### DIFF
--- a/snapd-glib/snapd-client.c
+++ b/snapd-glib/snapd-client.c
@@ -2537,14 +2537,14 @@ make_request (SnapdClient *client, RequestType request_type,
         request->auth_data = g_object_ref (priv->auth_data);
     request->client = client;
     request->request_type = request_type;
-    if (cancellable != NULL) {
-        request->cancellable = g_object_ref (cancellable);
-        request->cancelled_id = g_cancellable_connect (cancellable, G_CALLBACK (request_cancelled_cb), request, NULL);
-    }
     request->ready_callback = callback;
     request->ready_callback_data = user_data;
     request->progress_callback = progress_callback;
     request->progress_callback_data = progress_callback_data;
+    if (cancellable != NULL) {
+        request->cancellable = g_object_ref (cancellable);
+        request->cancelled_id = g_cancellable_connect (cancellable, G_CALLBACK (request_cancelled_cb), request, NULL);
+    }
     priv->requests = g_list_append (priv->requests, request);
 
     return request;
@@ -2572,6 +2572,7 @@ snapd_client_login_sync (SnapdClient *client,
                          GCancellable *cancellable, GError **error)
 {
     g_auto(SyncData) data = { 0 };
+    SnapdClientPrivate *priv;
 
     g_return_val_if_fail (SNAPD_IS_CLIENT (client), NULL);
     g_return_val_if_fail (username != NULL, NULL);

--- a/tests/test-glib.c
+++ b/tests/test-glib.c
@@ -1310,14 +1310,6 @@ test_find_name_private_not_logged_in (void)
     g_assert (snaps == NULL);
 }
 
-static gboolean
-cancel_cb (gpointer user_data)
-{
-    GCancellable *cancellable = user_data;
-    g_cancellable_cancel (cancellable);
-    return G_SOURCE_REMOVE;
-}
-
 static void
 test_find_cancel (void)
 {
@@ -1335,7 +1327,7 @@ test_find_cancel (void)
 
     /* Use a special query that never responds */
     cancellable = g_cancellable_new ();
-    g_idle_add (cancel_cb, cancellable);
+    g_cancellable_cancel (cancellable);
     snaps = snapd_client_find_sync (client, SNAPD_FIND_FLAGS_NONE, "do-not-respond", NULL, cancellable, &error);
     g_assert_error (error, G_IO_ERROR, G_IO_ERROR_CANCELLED);
     g_assert (snaps == NULL);

--- a/tests/test-qt.cpp
+++ b/tests/test-qt.cpp
@@ -1074,13 +1074,6 @@ test_find_name_private_not_logged_in ()
     g_assert_cmpint (findRequest->error (), ==, QSnapdRequest::AuthDataRequired);
 }
 
-static gboolean
-find_cancel_cb (QSnapdFindRequest *request)
-{
-    request->cancel ();
-    return G_SOURCE_REMOVE;
-}
-
 static void
 test_find_cancel (void)
 {
@@ -1093,7 +1086,7 @@ test_find_cancel (void)
 
     /* Use a special query that never responds */
     QScopedPointer<QSnapdFindRequest> findRequest (client.find (QSnapdClient::None, "do-not-respond"));
-    g_idle_add ((GSourceFunc) find_cancel_cb, findRequest.data ());
+    findRequest->cancel();
     findRequest->runSync ();
     g_assert_cmpint (findRequest->error (), ==, QSnapdRequest::Cancelled);
 }


### PR DESCRIPTION
See the commit message for my understanding of the issue. I admit to not being completely sure of the problem here, so it definitely needs review.

The user visible bug this is trying to fix is https://github.com/snapcore/snapd-glib/issues/10