### PR TITLE
Add API to control whether polkit authorisation checks allow interaction

### DIFF
--- a/snapd-glib/snapd-client.c
+++ b/snapd-glib/snapd-client.c
@@ -85,6 +85,9 @@ typedef struct
     GMutex requests_mutex;
     GList *requests;
 
+    /* Whether to send the X-Allow-Interaction request header */
+    gboolean allow_interaction;
+
     /* Data received from snapd */
     GMutex buffer_mutex;
     GByteArray *buffer;
@@ -450,6 +453,8 @@ headers_new (SnapdRequest *request, gboolean authorize)
     soup_message_headers_append (headers, "Connection", "keep-alive");
     if (priv->user_agent != NULL)
         soup_message_headers_append (headers, "User-Agent", priv->user_agent);
+    if (priv->allow_interaction)
+        soup_message_headers_append (headers, "X-Allow-Interaction", "true");
 
     accept_languages = get_accept_languages ();
     soup_message_headers_append (headers, "Accept-Language", accept_languages);
@@ -2604,6 +2609,49 @@ snapd_client_get_user_agent (SnapdClient *client)
 
     priv = snapd_client_get_instance_private (client);
     return priv->user_agent;
+}
+
+/**
+ * snapd_client_set_allow_interaction:
+ * @client: a #SnapdClient
+ * @allow_interaction: whether to allow interaction.
+ *
+ * Set whether snapd operations are allowed to interact with the user.
+ * This affects operations that use polkit authorisation.
+ * Defaults to TRUE.
+ *
+ * Since: 1.18
+ */
+void
+snapd_client_set_allow_interaction (SnapdClient *client, gboolean allow_interaction)
+{
+    SnapdClientPrivate *priv;
+
+    g_return_if_fail (SNAPD_IS_CLIENT (client));
+
+    priv = snapd_client_get_instance_private (client);
+    priv->allow_interaction = allow_interaction;
+}
+
+/**
+ * snapd_client_get_allow_interaction:
+ * @client: a #SnapdClient
+ *
+ * Get whether snapd operations are allowed to interact with the user.
+ *
+ * Returns: %TRUE if interaction is allowed.
+ *
+ * Since: 1.18
+ */
+gboolean
+snapd_client_get_allow_interaction (SnapdClient *client)
+{
+    SnapdClientPrivate *priv;
+
+    g_return_val_if_fail (SNAPD_IS_CLIENT (client), FALSE);
+
+    priv = snapd_client_get_instance_private (client);
+    return priv->allow_interaction;
 }
 
 static void
@@ -5972,6 +6020,7 @@ snapd_client_init (SnapdClient *client)
     SnapdClientPrivate *priv = snapd_client_get_instance_private (client);
 
     priv->user_agent = g_strdup ("snapd-glib/" VERSION);
+    priv->allow_interaction = TRUE;
     priv->buffer = g_byte_array_new ();
     g_mutex_init (&priv->requests_mutex);
     g_mutex_init (&priv->buffer_mutex);

--- a/snapd-glib/snapd-client.h
+++ b/snapd-glib/snapd-client.h
@@ -144,6 +144,11 @@ void                    snapd_client_set_user_agent                (SnapdClient 
 
 const gchar            *snapd_client_get_user_agent                (SnapdClient          *client);
 
+void                    snapd_client_set_allow_interaction         (SnapdClient          *client,
+                                                                    gboolean              allow_interaction);
+
+gboolean                snapd_client_get_allow_interaction         (SnapdClient          *client);
+
 SnapdAuthData          *snapd_client_login_sync                    (SnapdClient          *client,
                                                                     const gchar          *username,
                                                                     const gchar          *password,

--- a/snapd-qt/Snapd/client.h
+++ b/snapd-qt/Snapd/client.h
@@ -542,6 +542,7 @@ class Q_DECL_EXPORT QSnapdClient : public QObject
     Q_OBJECT
 
     Q_PROPERTY(QString userAgent READ userAgent WRITE setUserAgent)
+    Q_PROPERTY(bool allowInteraction READ allowInteraction WRITE setAllowInteraction)
     Q_FLAGS(FindFlags)
 
 public:
@@ -568,6 +569,8 @@ public:
     Q_INVOKABLE QSnapdLoginRequest *login (const QString& username, const QString& password, const QString& otp);
     Q_INVOKABLE void setUserAgent (const QString &userAgent);
     Q_INVOKABLE QString userAgent () const;
+    Q_INVOKABLE void setAllowInteraction (bool allowInteraction);
+    Q_INVOKABLE bool allowInteraction () const;
     Q_INVOKABLE void setAuthData (QSnapdAuthData *authData);
     Q_INVOKABLE QSnapdAuthData *authData ();
     Q_INVOKABLE QSnapdGetSystemInformationRequest *getSystemInformation ();

--- a/snapd-qt/client.cpp
+++ b/snapd-qt/client.cpp
@@ -98,6 +98,18 @@ QString QSnapdClient::userAgent () const
     return snapd_client_get_user_agent (d->client);
 }
 
+void QSnapdClient::setAllowInteraction (bool allowInteraction)
+{
+    Q_D(QSnapdClient);
+    snapd_client_set_allow_interaction (d->client, allowInteraction);
+}
+
+bool QSnapdClient::allowInteraction () const
+{
+    Q_D(const QSnapdClient);
+    return snapd_client_get_allow_interaction (d->client);
+}
+
 void QSnapdClient::setAuthData (QSnapdAuthData *authData)
 {
     Q_D(QSnapdClient);

--- a/tests/mock-snapd.c
+++ b/tests/mock-snapd.c
@@ -712,6 +712,15 @@ mock_snapd_get_last_accept_language (MockSnapd *snapd)
     return soup_message_headers_get_one (snapd->last_request_headers, "Accept-Language");
 }
 
+const gchar *
+mock_snapd_get_last_allow_interaction (MockSnapd *snapd)
+{
+    if (snapd->last_request_headers == NULL)
+        return NULL;
+
+    return soup_message_headers_get_one (snapd->last_request_headers, "X-Allow-Interaction");
+}
+
 static MockChange *
 add_change (MockSnapd *snapd, JsonNode *data)
 {

--- a/tests/mock-snapd.h
+++ b/tests/mock-snapd.h
@@ -262,6 +262,8 @@ const gchar    *mock_snapd_get_last_user_agent    (MockSnapd     *snapd);
 
 const gchar    *mock_snapd_get_last_accept_language (MockSnapd     *snapd);
 
+const gchar    *mock_snapd_get_last_allow_interaction (MockSnapd *snapd);
+
 G_END_DECLS
 
 #endif /* __MOCK_SNAPD_H__ */

--- a/tests/test-glib.c
+++ b/tests/test-glib.c
@@ -128,6 +128,37 @@ test_accept_language_empty (void)
 }
 
 static void
+test_allow_interaction (void)
+{
+    g_autoptr(MockSnapd) snapd = NULL;
+    g_autoptr(SnapdClient) client = NULL;
+    g_autoptr(GError) error = NULL;
+    g_autoptr(SnapdSystemInformation) info = NULL;
+
+    snapd = mock_snapd_new ();
+    client = snapd_client_new_from_socket (mock_snapd_get_client_socket (snapd));
+    snapd_client_connect_sync (client, NULL, &error);
+    g_assert_no_error (error);
+
+    /* By default, interaction is allowed */
+    g_assert (snapd_client_get_allow_interaction (client));
+
+    /* ... which sends the X-Allow-Interaction header with requests */
+    info = snapd_client_get_system_information_sync (client, NULL, &error);
+    g_assert_no_error (error);
+    g_assert (info != NULL);
+    g_assert_cmpstr (mock_snapd_get_last_allow_interaction (snapd), ==, "true");
+
+    /* If interaction is not allowed, the header is not sent */
+    snapd_client_set_allow_interaction (client, FALSE);
+    g_assert (!snapd_client_get_allow_interaction (client));
+    info = snapd_client_get_system_information_sync (client, NULL, &error);
+    g_assert_no_error (error);
+    g_assert (info != NULL);
+    g_assert_cmpstr (mock_snapd_get_last_allow_interaction (snapd), ==, NULL);
+}
+
+static void
 test_get_system_information (void)
 {
     g_autoptr(MockSnapd) snapd = NULL;
@@ -3477,6 +3508,7 @@ main (int argc, char **argv)
     g_test_add_func ("/user-agent/null", test_user_agent_null);
     g_test_add_func ("/accept-language/basic", test_accept_language);
     g_test_add_func ("/accept-language/empty", test_accept_language_empty);
+    g_test_add_func ("/allow-interaction/basic", test_allow_interaction);
     g_test_add_func ("/get-system-information/basic", test_get_system_information);
     g_test_add_func ("/get-system-information/async", test_get_system_information_async);
     g_test_add_func ("/get-system-information/store", test_get_system_information_store);


### PR DESCRIPTION
This branch is intended to complement https://github.com/snapcore/snapd/pull/3795 by adding `set_allow_interaction` and `get_allow_interaction` APIs to `SnapdClient`.  The idea is to let the client decide whether snapd's polkit authorisation checks should allow interaction or not.

One question is what the default should be for snapd-glib.  At present I've set it to default to allow interaction on the assumption that most users of the library will be graphical.  But it would be pretty easy to disallow interaction by default.

The change should be backward compatible with old versions of snapd: they will simply ignore the extra request header.