### PR TITLE
configure: json-glib 1.1 is enough to build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ dnl === Dependencies ==========================================================
 
 GLIB_REQUIRED=2.46
 LIBSOUP_REQUIRED=2.32
-JSON_GLIB_REQUIRED=1.2
+JSON_GLIB_REQUIRED=1.1.2
 
 PKG_CHECK_MODULES(SNAPD, [
     glib-2.0 >= $GLIB_REQUIRED


### PR DESCRIPTION
json-glib 1.2 is not available on Ubuntu 16.04 (xenial) but 1.1.2 is. A build
with 1.1.2 goes fine so lets use that as new baseline.