### PR TITLE
Fix runtime assertion when snapd socket is NULL

### DIFF
--- a/snapd-glib/snapd-client.c
+++ b/snapd-glib/snapd-client.c
@@ -6044,7 +6044,8 @@ snapd_client_finalize (GObject *object)
     g_clear_object (&priv->auth_data);
     g_list_free_full (priv->requests, g_object_unref);
     priv->requests = NULL;
-    g_socket_close (priv->snapd_socket, NULL);
+    if (priv->snapd_socket != NULL)
+        g_socket_close (priv->snapd_socket, NULL);
     g_clear_object (&priv->snapd_socket);
     g_clear_pointer (&priv->buffer, g_byte_array_unref);
 }


### PR DESCRIPTION
This was found whilst using the Python GIR bindings and deliberately
causing the snapd.socket service to fail (i.e. emulation of a missing
snapd service at runtime). During process exit and finalisation of the
SnapdClient object, the socket would be unconditionally closed regardless
of whether connection had succeeded or not.

This commit adds a very trivial guard around the cleanup.

Signed-off-by: Ikey Doherty <ikey@solus-project.com>