### PR TITLE
Reconnect to snapd if disconnected while trying to send the request

### DIFF
--- a/snapd-glib/snapd-client.c
+++ b/snapd-glib/snapd-client.c
@@ -793,6 +793,7 @@ send_request (SnapdClient *client, SnapdRequest *request)
     g_byte_array_append (request_data, (const guint8 *) buffer->data, buffer->length);
 
     for (retry = 0; retry < 2; retry++) {
+        g_clear_error (&local_error);
         if (data->read_source != NULL) {
             g_source_destroy (data->read_source);
             g_clear_pointer (&data->read_source, g_source_unref);
@@ -837,7 +838,6 @@ send_request (SnapdClient *client, SnapdRequest *request)
         n_written = g_socket_send (priv->snapd_socket, (const gchar *) request_data->data, request_data->len, _snapd_request_get_cancellable (request), &local_error);
         if (n_written < 0 && g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_CONNECTION_CLOSED)) {
             /* If the connection is closed, clear the socket and repeat */
-            g_clear_pointer (&local_error, g_error_free);
             g_clear_object (&priv->snapd_socket);
         } else {
             /* Otherwise, complete */

--- a/snapd-glib/snapd-client.c
+++ b/snapd-glib/snapd-client.c
@@ -129,6 +129,9 @@ G_DEFINE_TYPE_WITH_PRIVATE (SnapdClient, snapd_client, G_TYPE_OBJECT)
 /* Number of milliseconds to poll for status in asynchronous operations */
 #define ASYNC_POLL_TIME 100
 
+/* Number times to retry connecting to snapd whne sending messages */
+#define CONNECT_RETRY_COUNT 1
+
 typedef struct
 {
     int ref_count;
@@ -792,7 +795,7 @@ send_request (SnapdClient *client, SnapdRequest *request)
     buffer = soup_message_body_flatten (message->request_body);
     g_byte_array_append (request_data, (const guint8 *) buffer->data, buffer->length);
 
-    for (retry = 0; retry < 2; retry++) {
+    for (retry = 0; retry <= CONNECT_RETRY_COUNT; retry++) {
         g_clear_error (&local_error);
         if (data->read_source != NULL) {
             g_source_destroy (data->read_source);

--- a/snapd-glib/snapd-client.c
+++ b/snapd-glib/snapd-client.c
@@ -727,6 +727,7 @@ send_request (SnapdClient *client, SnapdRequest *request)
     g_autoptr(SoupBuffer) buffer = NULL;
     gssize n_written;
     g_autoptr(GError) local_error = NULL;
+    int retry;
 
     // NOTE: Would love to use libsoup but it doesn't support unix sockets
     // https://bugzilla.gnome.org/show_bug.cgi?id=727563
@@ -791,44 +792,60 @@ send_request (SnapdClient *client, SnapdRequest *request)
     buffer = soup_message_body_flatten (message->request_body);
     g_byte_array_append (request_data, (const guint8 *) buffer->data, buffer->length);
 
-    if (priv->snapd_socket == NULL) {
-        g_autoptr(GSocketAddress) address = NULL;
-        g_autoptr(GError) error_local = NULL;
-
-        priv->snapd_socket = g_socket_new (G_SOCKET_FAMILY_UNIX,
-                                           G_SOCKET_TYPE_STREAM,
-                                           G_SOCKET_PROTOCOL_DEFAULT,
-                                           &error_local);
-        if (priv->snapd_socket == NULL) {
-            g_autoptr(GError) error = g_error_new (SNAPD_ERROR,
-                                                   SNAPD_ERROR_CONNECTION_FAILED,
-                                                   "Unable to create snapd socket: %s",
-                                                   error_local->message);
-            snapd_request_complete (client, request, error);
-            return;
+    for (retry = 0; retry < 2; retry++) {
+        if (data->read_source != NULL) {
+            g_source_destroy (data->read_source);
+            g_clear_pointer (&data->read_source, g_source_unref);
         }
-        g_socket_set_blocking (priv->snapd_socket, FALSE);
-        address = g_unix_socket_address_new (priv->socket_path);
-        if (!g_socket_connect (priv->snapd_socket, address, _snapd_request_get_cancellable (request), &error_local)) {
+
+        if (priv->snapd_socket == NULL) {
+            g_autoptr(GSocketAddress) address = NULL;
+            g_autoptr(GError) error_local = NULL;
+
+            priv->snapd_socket = g_socket_new (G_SOCKET_FAMILY_UNIX,
+                                               G_SOCKET_TYPE_STREAM,
+                                               G_SOCKET_PROTOCOL_DEFAULT,
+                                               &error_local);
+            if (priv->snapd_socket == NULL) {
+                g_autoptr(GError) error = g_error_new (SNAPD_ERROR,
+                                                       SNAPD_ERROR_CONNECTION_FAILED,
+                                                       "Unable to create snapd socket: %s",
+                                                       error_local->message);
+                snapd_request_complete (client, request, error);
+                return;
+            }
+            g_socket_set_blocking (priv->snapd_socket, FALSE);
+            address = g_unix_socket_address_new (priv->socket_path);
+            if (!g_socket_connect (priv->snapd_socket, address, _snapd_request_get_cancellable (request), &error_local)) {
+                g_clear_object (&priv->snapd_socket);
+                g_autoptr(GError) error = g_error_new (SNAPD_ERROR,
+                                                       SNAPD_ERROR_CONNECTION_FAILED,
+                                                       "Unable to connect snapd socket: %s",
+                                                       error_local->message);
+                snapd_request_complete (client, request, error);
+                return;
+            }
+        }
+
+        data->read_source = g_socket_create_source (priv->snapd_socket, G_IO_IN, NULL);
+        g_source_set_name (data->read_source, "snapd-glib-read-source");
+        g_source_set_callback (data->read_source, (GSourceFunc) read_cb, client, NULL);
+        g_source_attach (data->read_source, _snapd_request_get_context (request));
+
+        /* send HTTP request */
+        // FIXME: Check for short writes
+        n_written = g_socket_send (priv->snapd_socket, (const gchar *) request_data->data, request_data->len, _snapd_request_get_cancellable (request), &local_error);
+        if (n_written < 0 && g_error_matches (local_error, G_IO_ERROR, G_IO_ERROR_CONNECTION_CLOSED)) {
+            /* If the connection is closed, clear the socket and repeat */
+            g_clear_pointer (&local_error, g_error_free);
             g_clear_object (&priv->snapd_socket);
-            g_autoptr(GError) error = g_error_new (SNAPD_ERROR,
-                                                   SNAPD_ERROR_CONNECTION_FAILED,
-                                                   "Unable to connect snapd socket: %s",
-                                                   error_local->message);
-            snapd_request_complete (client, request, error);
-            return;
+        } else {
+            /* Otherwise, complete */
+            break;
         }
     }
 
-    data->read_source = g_socket_create_source (priv->snapd_socket, G_IO_IN, NULL);
-    g_source_set_name (data->read_source, "snapd-glib-read-source");
-    g_source_set_callback (data->read_source, (GSourceFunc) read_cb, client, NULL);
-    g_source_attach (data->read_source, _snapd_request_get_context (request));
-
-    /* send HTTP request */
-    // FIXME: Check for short writes
-    n_written = g_socket_send (priv->snapd_socket, (const gchar *) request_data->data, request_data->len, _snapd_request_get_cancellable (request), &local_error);
-    if (n_written < 0) {
+    if (local_error != NULL) {
         g_autoptr(GError) error = g_error_new (SNAPD_ERROR,
                                                SNAPD_ERROR_WRITE_FAILED,
                                                "Failed to write to snapd: %s",

--- a/tests/mock-snapd.c
+++ b/tests/mock-snapd.c
@@ -3976,8 +3976,6 @@ mock_snapd_finalize (GObject *object)
     /* shut down the server if it is running */
     mock_snapd_stop (snapd);
 
-    if (g_unlink (snapd->socket_path) < 0)
-        g_printerr ("Failed to unlink mock snapd socket\n");
     if (g_rmdir (snapd->dir_path) < 0)
         g_printerr ("Failed to remove temporary directory\n");
 

--- a/tests/test-glib.c
+++ b/tests/test-glib.c
@@ -109,6 +109,40 @@ test_socket_closed_reconnect (void)
 }
 
 static void
+test_socket_closed_reconnect_after_failure (void)
+{
+    g_autoptr(MockSnapd) snapd = NULL;
+    g_autoptr(SnapdClient) client = NULL;
+    g_autoptr(SnapdSystemInformation) info = NULL;
+    g_autoptr(GError) error = NULL;
+
+    snapd = mock_snapd_new ();
+    g_assert_true (mock_snapd_start (snapd, &error));
+
+    client = snapd_client_new ();
+    snapd_client_set_socket_path (client, mock_snapd_get_socket_path (snapd));
+
+    info = snapd_client_get_system_information_sync (client, NULL, &error);
+    g_assert_no_error (error);
+    g_assert_nonnull (info);
+    g_clear_object (&info);
+
+    mock_snapd_stop (snapd);
+
+    info = snapd_client_get_system_information_sync (client, NULL, &error);
+    g_assert_null (info);
+    g_assert_error (error, SNAPD_ERROR, SNAPD_ERROR_CONNECTION_FAILED);
+    g_clear_error (&error);
+
+    g_assert_true (mock_snapd_start (snapd, &error));
+
+    info = snapd_client_get_system_information_sync (client, NULL, &error);
+    g_assert_no_error (error);
+    g_assert_nonnull (info);
+    g_clear_object (&info);
+}
+
+static void
 test_user_agent_default (void)
 {
     g_autoptr(MockSnapd) snapd = NULL;
@@ -6920,6 +6954,7 @@ main (int argc, char **argv)
     g_test_add_func ("/socket-closed/before-request", test_socket_closed_before_request);
     g_test_add_func ("/socket-closed/after-request", test_socket_closed_after_request);
     g_test_add_func ("/socket-closed/reconnect", test_socket_closed_reconnect);
+    g_test_add_func ("/socket-closed/reconnect-after-failure", test_socket_closed_reconnect_after_failure);
     g_test_add_func ("/user-agent/default", test_user_agent_default);
     g_test_add_func ("/user-agent/custom", test_user_agent_custom);
     g_test_add_func ("/user-agent/null", test_user_agent_null);

--- a/tests/test-glib.c
+++ b/tests/test-glib.c
@@ -81,6 +81,34 @@ test_socket_closed_after_request (void)
 }
 
 static void
+test_socket_closed_reconnect (void)
+{
+    g_autoptr(MockSnapd) snapd = NULL;
+    g_autoptr(SnapdClient) client = NULL;
+    g_autoptr(SnapdSystemInformation) info = NULL;
+    g_autoptr(GError) error = NULL;
+
+    snapd = mock_snapd_new ();
+    g_assert_true (mock_snapd_start (snapd, &error));
+
+    client = snapd_client_new ();
+    snapd_client_set_socket_path (client, mock_snapd_get_socket_path (snapd));
+
+    info = snapd_client_get_system_information_sync (client, NULL, &error);
+    g_assert_no_error (error);
+    g_assert_nonnull (info);
+    g_clear_object (&info);
+
+    mock_snapd_stop (snapd);
+    g_assert_true (mock_snapd_start (snapd, &error));
+
+    info = snapd_client_get_system_information_sync (client, NULL, &error);
+    g_assert_no_error (error);
+    g_assert_nonnull (info);
+    g_clear_object (&info);
+}
+
+static void
 test_user_agent_default (void)
 {
     g_autoptr(MockSnapd) snapd = NULL;
@@ -6891,6 +6919,7 @@ main (int argc, char **argv)
 
     g_test_add_func ("/socket-closed/before-request", test_socket_closed_before_request);
     g_test_add_func ("/socket-closed/after-request", test_socket_closed_after_request);
+    g_test_add_func ("/socket-closed/reconnect", test_socket_closed_reconnect);
     g_test_add_func ("/user-agent/default", test_user_agent_default);
     g_test_add_func ("/user-agent/custom", test_user_agent_custom);
     g_test_add_func ("/user-agent/null", test_user_agent_null);


### PR DESCRIPTION
If the remote end has disconnected our socket connection, we will only see the error when we next try to write a request to snapd.  If we see this error, we should reconnect and try again.

I've also added a boolean flag to prevent us looping endlessly if snapd is misbehaving.