### PR TITLE
Ensure a request is completed only once.

### DIFF
--- a/snapd-glib/requests/snapd-request.c
+++ b/snapd-glib/requests/snapd-request.c
@@ -87,14 +87,14 @@ respond_cb (gpointer user_data)
     return G_SOURCE_REMOVE;
 }
 
-void
+gboolean
 _snapd_request_return (SnapdRequest *request, GError *error)
 {
     g_autoptr(GSource) source = NULL;
     SnapdRequestPrivate *priv = snapd_request_get_instance_private (request);
 
     if (priv->responded)
-        return;
+        return FALSE;
     priv->responded = TRUE;
     if (error != NULL)
         priv->error = g_error_copy (error);
@@ -102,6 +102,8 @@ _snapd_request_return (SnapdRequest *request, GError *error)
     source = g_idle_source_new ();
     g_source_set_callback (source, respond_cb, g_object_ref (request), g_object_unref);
     g_source_attach (source, _snapd_request_get_context (request));
+
+    return TRUE;
 }
 
 gboolean

--- a/snapd-glib/requests/snapd-request.h
+++ b/snapd-glib/requests/snapd-request.h
@@ -36,7 +36,7 @@ void          _snapd_request_generate          (SnapdRequest *request);
 
 SoupMessage  *_snapd_request_get_message       (SnapdRequest *request);
 
-void          _snapd_request_return            (SnapdRequest *request,
+gboolean       _snapd_request_return           (SnapdRequest *request,
                                                 GError       *error);
 
 gboolean      _snapd_request_propagate_error   (SnapdRequest *request,

--- a/snapd-glib/snapd-client.c
+++ b/snapd-glib/snapd-client.c
@@ -186,11 +186,11 @@ snapd_request_complete_unlocked (SnapdClient *client, SnapdRequest *request, GEr
 {
     SnapdClientPrivate *priv = snapd_client_get_instance_private (client);
 
-    g_hash_table_remove (priv->request_data, request);
-
-    _snapd_request_return (request, error);
-    priv->requests = g_list_remove (priv->requests, request);
-    g_object_unref (request);
+    if (_snapd_request_return (request, error)) {
+        g_hash_table_remove (priv->request_data, request);
+        priv->requests = g_list_remove (priv->requests, request);
+        g_object_unref (request);
+    }
 }
 
 static void


### PR DESCRIPTION
The function snapd_request_complete is called twice for the same SnapdRequest in
case the request is cancelled after a response message has already been received
and parsed. In order to avoid double refs we need to enforce that a request
cannot be completed twice.

Fixes: https://bugs.launchpad.net/bugs/1798360