### PR TITLE
Remove screenshot decoding code

### DIFF
--- a/snapd-glib/requests/snapd-json.c
+++ b/snapd-glib/requests/snapd-json.c
@@ -769,24 +769,7 @@ _snapd_json_parse_snap (JsonNode *node, GError **error)
         g_ptr_array_add (media_array, g_steal_pointer (&media));
     }
 
-    g_autoptr(JsonArray) screenshots = _snapd_json_get_array (object, "screenshots");
     g_autoptr(GPtrArray) screenshots_array = g_ptr_array_new_with_free_func (g_object_unref);
-    for (guint i = 0; i < json_array_get_length (screenshots); i++) {
-        JsonNode *node = json_array_get_element (screenshots, i);
-
-        if (json_node_get_value_type (node) != JSON_TYPE_OBJECT) {
-            g_set_error (error, SNAPD_ERROR, SNAPD_ERROR_READ_FAILED, "Unexpected screenshot type");
-            return NULL;
-        }
-
-        JsonObject *s = json_node_get_object (node);
-        g_autoptr(SnapdScreenshot) screenshot = g_object_new (SNAPD_TYPE_SCREENSHOT,
-                                                              "url", _snapd_json_get_string (s, "url", NULL),
-                                                              "width", (guint) _snapd_json_get_int (s, "width", 0),
-                                                              "height", (guint) _snapd_json_get_int (s, "height", 0),
-                                                              NULL);
-        g_ptr_array_add (screenshots_array, g_steal_pointer (&screenshot));
-    }
 
     /* The tracks field was originally incorrectly named, fixed in snapd 61ad9ed (2.29.5) */
     g_autoptr(JsonArray) tracks = NULL;

--- a/tests/mock-snapd.c
+++ b/tests/mock-snapd.c
@@ -2422,28 +2422,13 @@ make_snap_node (MockSnap *snap)
     json_builder_add_string_value (builder, resource);
     json_builder_set_member_name (builder, "revision");
     json_builder_add_string_value (builder, snap->revision);
-    if (screenshot_count > 0) {
-        json_builder_set_member_name (builder, "screenshots");
-        json_builder_begin_array (builder);
-        for (GList *link = snap->media; link; link = link->next) {
-            MockMedia *media = link->data;
-
-            if (strcmp (media->type, "screenshot") != 0)
-                continue;
-
-            json_builder_begin_object (builder);
-            json_builder_set_member_name (builder, "url");
-            json_builder_add_string_value (builder, media->url);
-            if (media->width > 0 && media->height > 0) {
-                json_builder_set_member_name (builder, "width");
-                json_builder_add_int_value (builder, media->width);
-                json_builder_set_member_name (builder, "height");
-                json_builder_add_int_value (builder, media->height);
-            }
-            json_builder_end_object (builder);
-        }
-        json_builder_end_array (builder);
-    }
+    json_builder_set_member_name (builder, "screenshots");
+    json_builder_begin_array (builder);
+    json_builder_begin_object (builder);
+    json_builder_set_member_name (builder, "note");
+    json_builder_add_string_value (builder, "'screenshots' is deprecated; use 'media' instead. More info at https://forum.snapcraft.io/t/8086");
+    json_builder_end_object (builder);
+    json_builder_end_array (builder);
     json_builder_set_member_name (builder, "status");
     json_builder_add_string_value (builder, snap->status);
     if (snap->summary) {

--- a/tests/test-glib.c
+++ b/tests/test-glib.c
@@ -4003,12 +4003,7 @@ test_find_query (void)
     g_assert_false (snapd_snap_get_private (snap));
     g_assert_cmpstr (snapd_snap_get_revision (snap), ==, "REVISION");
 G_GNUC_BEGIN_IGNORE_DEPRECATIONS
-    GPtrArray *screenshots = snapd_snap_get_screenshots (snap);
-    g_assert_cmpint (screenshots->len, ==, 2);
-    g_assert_cmpstr (snapd_screenshot_get_url (screenshots->pdata[0]), ==, "screenshot0.png");
-    g_assert_cmpstr (snapd_screenshot_get_url (screenshots->pdata[1]), ==, "screenshot1.png");
-    g_assert_cmpint (snapd_screenshot_get_width (screenshots->pdata[1]), ==, 1024);
-    g_assert_cmpint (snapd_screenshot_get_height (screenshots->pdata[1]), ==, 1024);
+    g_assert_cmpint (snapd_snap_get_screenshots (snap)->len, ==, 0);
 G_GNUC_END_IGNORE_DEPRECATIONS
     g_assert_cmpint (snapd_snap_get_snap_type (snap), ==, SNAPD_SNAP_TYPE_APP);
     g_assert_cmpint (snapd_snap_get_status (snap), ==, SNAPD_SNAP_STATUS_ACTIVE);

--- a/tests/test-qt.cpp
+++ b/tests/test-qt.cpp
@@ -3462,13 +3462,7 @@ test_find_query ()
     g_assert (snap1->revision () == "REVISION");
 QT_WARNING_PUSH
 QT_WARNING_DISABLE_DEPRECATED
-    g_assert_cmpint (snap1->screenshotCount (), ==, 2);
-    QScopedPointer<QSnapdScreenshot> screenshot0 (snap1->screenshot (0));
-    g_assert (screenshot0->url () == "screenshot0.png");
-    QScopedPointer<QSnapdScreenshot> screenshot1 (snap1->screenshot (1));
-    g_assert (screenshot1->url () == "screenshot1.png");
-    g_assert_cmpint (screenshot1->width (), ==, 1024);
-    g_assert_cmpint (screenshot1->height (), ==, 1024);
+    g_assert_cmpint (snap1->screenshotCount (), ==, 0);
 QT_WARNING_POP
     g_assert_cmpint (snap1->snapType (), ==, QSnapdEnums::SnapTypeApp);
     g_assert_cmpint (snap1->status (), ==, QSnapdEnums::SnapStatusActive);


### PR DESCRIPTION
snapd hasn't populated these since 2.40 and instead puts in a note that is
confusing snapd-glib into thinking there is one screenshot.

snapd-glib will now always return 0 screenshots.