### PR TITLE
Make the build reproducible

### DIFF
--- a/snapd-glib/snapd-enum-types.c.in
+++ b/snapd-glib/snapd-enum-types.c.in
@@ -13,7 +13,7 @@
 
 /*** BEGIN file-production ***/
 
-/* enumerations from "@filename@" */
+/* enumerations from "@basename@" */
 #include "@filename@"
 
 /*** END file-production ***/

--- a/snapd-glib/snapd-enum-types.h.in
+++ b/snapd-glib/snapd-enum-types.h.in
@@ -22,7 +22,7 @@ G_BEGIN_DECLS
 /*** END file-header ***/
 
 /*** BEGIN file-production ***/
-/* enumerations from "@filename@" */
+/* enumerations from "@basename@" */
 /*** END file-production ***/
 
 /*** BEGIN file-tail ***/


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort we noticed that snapd-glib could not be built reproducibly. This is because it embedded the full build path in comments.

This was originally filed in Debian as [#952694](https://bugs.debian.org/952694).