### PR TITLE
Fix annotations for SnapdClient.get_snap_conf

### DIFF
--- a/snapd-glib/snapd-client-sync.c
+++ b/snapd-glib/snapd-client-sync.c
@@ -340,7 +340,7 @@ snapd_client_get_snap_sync (SnapdClient *self,
  *
  * Get configuration for a snap. System configuration is stored using the name "system".
  *
- * Returns: (transfer full) (element-type utf8 GVariant): a table of configuration values or %NULL on error.
+ * Returns: (transfer container) (element-type utf8 GVariant): a table of configuration values or %NULL on error.
  *
  * Since: 1.48
  */

--- a/snapd-glib/snapd-client.c
+++ b/snapd-glib/snapd-client.c
@@ -1588,7 +1588,7 @@ snapd_client_get_snap_conf_async (SnapdClient *self,
  * Complete request started with snapd_client_get_snap_conf_async().
  * See snapd_client_get_snap_conf_sync() for more information.
  *
- * Returns: (transfer full) (element-type utf8 GVariant): a table of configuration values or %NULL on error.
+ * Returns: (transfer container) (element-type utf8 GVariant): a table of configuration values or %NULL on error.
  *
  * Since: 1.48
  */


### PR DESCRIPTION
The previous annotations would cause Python to crash, due to it freeing the
elements on the hash table (which are freed by the hash table itself).

Fixes https://github.com/snapcore/snapd-glib/issues/88