### PR TITLE
snapd-glib: add error_value out parameter to _snapd_json_parse_response

### DIFF
--- a/snapd-glib/requests/snapd-get-aliases.c
+++ b/snapd-glib/requests/snapd-get-aliases.c
@@ -50,7 +50,7 @@ parse_get_aliases_response (SnapdRequest *request, SoupMessage *message, SnapdMa
 {
     SnapdGetAliases *self = SNAPD_GET_ALIASES (request);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     g_autoptr(JsonObject) result = _snapd_json_get_sync_result_o (response, error);

--- a/snapd-glib/requests/snapd-get-apps.c
+++ b/snapd-glib/requests/snapd-get-apps.c
@@ -81,7 +81,7 @@ parse_get_apps_response (SnapdRequest *request, SoupMessage *message, SnapdMaint
 {
     SnapdGetApps *self = SNAPD_GET_APPS (request);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     g_autoptr(JsonArray) result = _snapd_json_get_sync_result_a (response, error);

--- a/snapd-glib/requests/snapd-get-assertions.c
+++ b/snapd-glib/requests/snapd-get-assertions.c
@@ -61,7 +61,7 @@ parse_get_assertions_response (SnapdRequest *request, SoupMessage *message, Snap
 
     const gchar *content_type = soup_message_headers_get_content_type (message->response_headers, NULL);
     if (g_strcmp0 (content_type, "application/json") == 0) {
-        g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+        g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
         if (response == NULL)
             return FALSE;
         g_autoptr(JsonObject) result = _snapd_json_get_sync_result_o (response, error);

--- a/snapd-glib/requests/snapd-get-buy-ready.c
+++ b/snapd-glib/requests/snapd-get-buy-ready.c
@@ -37,7 +37,7 @@ generate_get_buy_ready_request (SnapdRequest *request)
 static gboolean
 parse_get_buy_ready_response (SnapdRequest *request, SoupMessage *message, SnapdMaintenance **maintenance, GError **error)
 {
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
 

--- a/snapd-glib/requests/snapd-get-change.c
+++ b/snapd-glib/requests/snapd-get-change.c
@@ -67,7 +67,7 @@ parse_get_change_response (SnapdRequest *request, SoupMessage *message, SnapdMai
 {
     SnapdGetChange *self = SNAPD_GET_CHANGE (request);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     /* FIXME: Needs json-glib to be fixed to use json_node_unref */

--- a/snapd-glib/requests/snapd-get-changes.c
+++ b/snapd-glib/requests/snapd-get-changes.c
@@ -75,7 +75,7 @@ parse_get_changes_response (SnapdRequest *request, SoupMessage *message, SnapdMa
 {
     SnapdGetChanges *self = SNAPD_GET_CHANGES (request);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     g_autoptr(JsonArray) result = _snapd_json_get_sync_result_a (response, error);

--- a/snapd-glib/requests/snapd-get-connections.c
+++ b/snapd-glib/requests/snapd-get-connections.c
@@ -102,7 +102,7 @@ parse_get_connections_response (SnapdRequest *request, SoupMessage *message, Sna
 {
     SnapdGetConnections *self = SNAPD_GET_CONNECTIONS (request);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     g_autoptr(JsonObject) result = _snapd_json_get_sync_result_o (response, error);

--- a/snapd-glib/requests/snapd-get-find.c
+++ b/snapd-glib/requests/snapd-get-find.c
@@ -142,7 +142,7 @@ parse_get_find_response (SnapdRequest *request, SoupMessage *message, SnapdMaint
 {
     SnapdGetFind *self = SNAPD_GET_FIND (request);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     g_autoptr(JsonArray) result = _snapd_json_get_sync_result_a (response, error);

--- a/snapd-glib/requests/snapd-get-icon.c
+++ b/snapd-glib/requests/snapd-get-icon.c
@@ -58,7 +58,7 @@ parse_get_icon_response (SnapdRequest *request, SoupMessage *message, SnapdMaint
 
     const gchar *content_type = soup_message_headers_get_content_type (message->response_headers, NULL);
     if (g_strcmp0 (content_type, "application/json") == 0) {
-        g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+        g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
         if (response == NULL)
             return FALSE;
         g_autoptr(JsonObject) result = _snapd_json_get_sync_result_o (response, error);

--- a/snapd-glib/requests/snapd-get-interfaces-legacy.c
+++ b/snapd-glib/requests/snapd-get-interfaces-legacy.c
@@ -58,7 +58,7 @@ parse_get_interfaces_legacy_response (SnapdRequest *request, SoupMessage *messag
 {
     SnapdGetInterfacesLegacy *self = SNAPD_GET_INTERFACES_LEGACY (request);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     g_autoptr(JsonObject) result = _snapd_json_get_sync_result_o (response, error);

--- a/snapd-glib/requests/snapd-get-interfaces.c
+++ b/snapd-glib/requests/snapd-get-interfaces.c
@@ -107,7 +107,7 @@ parse_get_interfaces_response (SnapdRequest *request, SoupMessage *message, Snap
 {
     SnapdGetInterfaces *self = SNAPD_GET_INTERFACES (request);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, NULL, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, NULL, NULL, error);
     if (response == NULL)
         return FALSE;
     g_autoptr(JsonArray) result = _snapd_json_get_sync_result_a (response, error);

--- a/snapd-glib/requests/snapd-get-sections.c
+++ b/snapd-glib/requests/snapd-get-sections.c
@@ -47,7 +47,7 @@ parse_get_sections_response (SnapdRequest *request, SoupMessage *message, SnapdM
 {
     SnapdGetSections *self = SNAPD_GET_SECTIONS (request);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     g_autoptr(JsonArray) result = _snapd_json_get_sync_result_a (response, error);

--- a/snapd-glib/requests/snapd-get-snap-conf.c
+++ b/snapd-glib/requests/snapd-get-snap-conf.c
@@ -73,7 +73,7 @@ parse_get_snap_conf_response (SnapdRequest *request, SoupMessage *message, Snapd
 {
     SnapdGetSnapConf *self = SNAPD_GET_SNAP_CONF (request);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     g_autoptr(JsonObject) result = _snapd_json_get_sync_result_o (response, error);

--- a/snapd-glib/requests/snapd-get-snap.c
+++ b/snapd-glib/requests/snapd-get-snap.c
@@ -55,7 +55,7 @@ parse_get_snap_response (SnapdRequest *request, SoupMessage *message, SnapdMaint
 {
     SnapdGetSnap *self = SNAPD_GET_SNAP (request);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     /* FIXME: Needs json-glib to be fixed to use json_node_unref */

--- a/snapd-glib/requests/snapd-get-snaps.c
+++ b/snapd-glib/requests/snapd-get-snaps.c
@@ -79,7 +79,7 @@ parse_get_snaps_response (SnapdRequest *request, SoupMessage *message, SnapdMain
 {
     SnapdGetSnaps *self = SNAPD_GET_SNAPS (request);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     g_autoptr(JsonArray) result = _snapd_json_get_sync_result_a (response, error);

--- a/snapd-glib/requests/snapd-get-system-info.c
+++ b/snapd-glib/requests/snapd-get-system-info.c
@@ -49,7 +49,7 @@ parse_get_system_info_response (SnapdRequest *request, SoupMessage *message, Sna
 {
     SnapdGetSystemInfo *self = SNAPD_GET_SYSTEM_INFO (request);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     /* FIXME: Needs json-glib to be fixed to use json_node_unref */

--- a/snapd-glib/requests/snapd-get-users.c
+++ b/snapd-glib/requests/snapd-get-users.c
@@ -47,7 +47,7 @@ parse_get_users_response (SnapdRequest *request, SoupMessage *message, SnapdMain
 {
     SnapdGetUsers *self = SNAPD_GET_USERS (request);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     g_autoptr(JsonArray) result = _snapd_json_get_sync_result_a (response, error);

--- a/snapd-glib/requests/snapd-json.c
+++ b/snapd-glib/requests/snapd-json.c
@@ -185,7 +185,8 @@ parse_error_response (JsonObject *root, JsonNode **error_value, GError **error)
 
     if (error_value != NULL) {
         *error_value = result != NULL ? json_object_get_member (result, "value") : NULL;
-        json_node_ref (*error_value);
+        if (*error_value != NULL)
+            json_node_ref (*error_value);
     }
 
     if (g_strcmp0 (kind, "login-required") == 0)

--- a/snapd-glib/requests/snapd-json.h
+++ b/snapd-glib/requests/snapd-json.h
@@ -55,6 +55,7 @@ GDateTime            *_snapd_json_get_date_time          (JsonObject         *ob
 
 JsonObject           *_snapd_json_parse_response         (SoupMessage        *message,
                                                           SnapdMaintenance **maintenance,
+                                                          JsonNode          **error_value,
                                                           GError            **error);
 
 JsonNode             *_snapd_json_get_sync_result        (JsonObject         *response,

--- a/snapd-glib/requests/snapd-post-assertions.c
+++ b/snapd-glib/requests/snapd-post-assertions.c
@@ -56,7 +56,7 @@ generate_post_assertions_request (SnapdRequest *request)
 static gboolean
 parse_post_assertions_response (SnapdRequest *request, SoupMessage *message, SnapdMaintenance **maintenance, GError **error)
 {
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
 

--- a/snapd-glib/requests/snapd-post-buy.c
+++ b/snapd-glib/requests/snapd-post-buy.c
@@ -62,7 +62,7 @@ generate_post_buy_request (SnapdRequest *request)
 static gboolean
 parse_post_buy_response (SnapdRequest *request, SoupMessage *message, SnapdMaintenance **maintenance, GError **error)
 {
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
 

--- a/snapd-glib/requests/snapd-post-change.c
+++ b/snapd-glib/requests/snapd-post-change.c
@@ -78,7 +78,7 @@ parse_post_change_response (SnapdRequest *request, SoupMessage *message, SnapdMa
 {
     SnapdPostChange *self = SNAPD_POST_CHANGE (request);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     /* FIXME: Needs json-glib to be fixed to use json_node_unref */

--- a/snapd-glib/requests/snapd-post-create-user.c
+++ b/snapd-glib/requests/snapd-post-create-user.c
@@ -85,7 +85,7 @@ parse_post_create_user_response (SnapdRequest *request, SoupMessage *message, Sn
 {
     SnapdPostCreateUser *self = SNAPD_POST_CREATE_USER (request);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     /* FIXME: Needs json-glib to be fixed to use json_node_unref */

--- a/snapd-glib/requests/snapd-post-create-users.c
+++ b/snapd-glib/requests/snapd-post-create-users.c
@@ -56,7 +56,7 @@ parse_post_create_users_response (SnapdRequest *request, SoupMessage *message, S
 {
     SnapdPostCreateUsers *self = SNAPD_POST_CREATE_USERS (request);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     g_autoptr(JsonArray) result = _snapd_json_get_sync_result_a (response, error);

--- a/snapd-glib/requests/snapd-post-login.c
+++ b/snapd-glib/requests/snapd-post-login.c
@@ -76,7 +76,7 @@ parse_post_login_response (SnapdRequest *request, SoupMessage *message, SnapdMai
 {
     SnapdPostLogin *self = SNAPD_POST_LOGIN (request);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     /* FIXME: Needs json-glib to be fixed to use json_node_unref */

--- a/snapd-glib/requests/snapd-post-logout.c
+++ b/snapd-glib/requests/snapd-post-logout.c
@@ -54,7 +54,7 @@ generate_post_logout_request (SnapdRequest *request)
 static gboolean
 parse_post_logout_response (SnapdRequest *request, SoupMessage *message, SnapdMaintenance **maintenance, GError **error)
 {
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     /* FIXME: Needs json-glib to be fixed to use json_node_unref */

--- a/snapd-glib/requests/snapd-post-snapctl.c
+++ b/snapd-glib/requests/snapd-post-snapctl.c
@@ -75,7 +75,7 @@ parse_post_snapctl_response (SnapdRequest *request, SoupMessage *message, SnapdM
 {
     SnapdPostSnapctl *self = SNAPD_POST_SNAPCTL (request);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     g_autoptr(JsonObject) result = _snapd_json_get_sync_result_o (response, error);

--- a/snapd-glib/requests/snapd-request-async.c
+++ b/snapd-glib/requests/snapd-request-async.c
@@ -55,7 +55,7 @@ parse_async_response (SnapdRequest *self, SoupMessage *message, SnapdMaintenance
     SnapdRequestAsync *r = SNAPD_REQUEST_ASYNC (self);
     SnapdRequestAsyncPrivate *priv = snapd_request_async_get_instance_private (r);
 
-    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, error);
+    g_autoptr(JsonObject) response = _snapd_json_parse_response (message, maintenance, NULL, error);
     if (response == NULL)
         return FALSE;
     g_autofree gchar *change_id = _snapd_json_get_async_result (response, error);


### PR DESCRIPTION
This PR modifies the _snapd_json_parse_response` utility function to add a `JsonNode **error_value` out parameter that will be set to the `value` property of error responses it decodes.

The eventual goal is to update the `snapd_client_run_snapctl*` functions to correctly support non-zero exit codes, which are returned by snapd as error responses with the exit code, and command output stored in the error value.  I've submitted this PR on its own since it touches every request handler class, and didn't want to mix in a largely mechanical changes with ones that deserve more scrutiny.