### PR TITLE
ci: enble Github Actions based CI, using Travis script as a base

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,43 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        image:
+          - ubuntu:rolling
+          - ubuntu:20.04
+          - ubuntu:18.04
+          - fedora:latest
+
+    runs-on: ubuntu-latest
+    container: ${{ matrix.image }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies (Ubuntu)
+        if: startsWith(matrix.image, 'ubuntu:')
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends gtk-doc-tools libgirepository1.0-dev libglib2.0-dev libjson-glib-dev libsoup2.4-dev ninja-build python3-pip python3-setuptools python3-wheel qtbase5-dev qtdeclarative5-dev valac
+
+      - name: Install dependencies (Fedora)
+        if: startsWith(matrix.image, 'fedora:')
+        run: |
+          dnf install -y gcc gcc-c++ gobject-introspection-devel glib2-devel gtk-doc json-glib-devel libsoup-devel ninja-build python3-pip qt5-qtbase-devel qt5-qtdeclarative-devel redhat-rpm-config vala
+
+      - name: Install meson
+        run: pip3 install meson
+
+      - name: Build
+        run: |
+          meson _build
+          ninja -C _build
+          ninja -C _build snapd-glib-doc

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,3 +41,6 @@ jobs:
           meson _build
           ninja -C _build
           ninja -C _build snapd-glib-doc
+
+      - name: Test
+        run: ninja -C _build test


### PR DESCRIPTION
travis-ci.org has a banner saying it will be shut down in a few weeks, and that projects would be migrated to travis-ci.com.  It seems there is no longer an Open Source plan with the .com service, and the project would be switched to a trial plan that would eventually run out of minutes.

As an alternative, this PR ports the CI over to using Github Actions.  I've done a a mostly direct conversion of the Travis build script, only taking advantage of GH Actions built-in docker container syntax, and the conditional syntax for enabling container specific set up.

A sample run of the workflow can be seen here:

https://github.com/jhenstridge/snapd-glib/actions/runs/550765880