### PR TITLE
ci: collect Meson's log files on failed builds

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,6 +22,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Initialise parameters
+        id: params
+        run: |
+          artifact_name="logs-$(echo "${{ matrix.image }}" | sed "s/:/-/")"
+          echo "::set-output name=artifact::$artifact_name"
+
       - name: Install dependencies (Ubuntu)
         if: startsWith(matrix.image, 'ubuntu:')
         run: |
@@ -49,5 +55,5 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ matrix.image }} logs
+          name: ${{ steps.params.outputs.artifact }}
           path: _build/meson-logs

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,3 +44,10 @@ jobs:
 
       - name: Test
         run: ninja -C _build test
+
+      - name: Collect logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.image }} logs
+          path: _build/meson-logs


### PR DESCRIPTION
Add an extra step to the CI to collect the meson log files if the job fails.  Each job has a unique artifact name so that logs from different matrix runs don't overwrite each other.