### PR TITLE
snapd-glib: use /v2/accessories/changes endpoint to check status of themes requests

### DIFF
--- a/snapd-glib/requests/snapd-get-change.c
+++ b/snapd-glib/requests/snapd-get-change.c
@@ -18,7 +18,7 @@ struct _SnapdGetChange
     gchar *change_id;
     SnapdChange *change;
     JsonNode *data;
-    gboolean accessories_change;
+    gchar *api_path;
 };
 
 G_DEFINE_TYPE (SnapdGetChange, snapd_get_change, snapd_request_get_type ())
@@ -55,9 +55,10 @@ _snapd_get_change_get_data (SnapdGetChange *self)
 }
 
 void
-_snapd_get_change_set_accessories_change (SnapdGetChange *self, gboolean accessories_change)
+_snapd_get_change_set_api_path (SnapdGetChange *self, const gchar *api_path)
 {
-    self->accessories_change = accessories_change;
+    g_free (self->api_path);
+    self->api_path = g_strdup (api_path);
 }
 
 static SoupMessage *
@@ -65,7 +66,7 @@ generate_get_change_request (SnapdRequest *request)
 {
     SnapdGetChange *self = SNAPD_GET_CHANGE (request);
 
-    g_autofree gchar *path = g_strdup_printf ("http://snapd%s/%s", self->accessories_change ? "/v2/accessories/changes" : "/v2/changes", self->change_id);
+    g_autofree gchar *path = g_strdup_printf ("http://snapd%s/%s", self->api_path ? self->api_path : "/v2/changes", self->change_id);
     return soup_message_new ("GET", path);
 }
 
@@ -110,6 +111,7 @@ snapd_get_change_finalize (GObject *object)
     g_clear_pointer (&self->change_id, g_free);
     g_clear_object (&self->change);
     g_clear_pointer (&self->data, json_node_unref);
+    g_clear_pointer (&self->api_path, g_free);
 
     G_OBJECT_CLASS (snapd_get_change_parent_class)->finalize (object);
 }

--- a/snapd-glib/requests/snapd-get-change.c
+++ b/snapd-glib/requests/snapd-get-change.c
@@ -18,6 +18,7 @@ struct _SnapdGetChange
     gchar *change_id;
     SnapdChange *change;
     JsonNode *data;
+    gboolean accessories_change;
 };
 
 G_DEFINE_TYPE (SnapdGetChange, snapd_get_change, snapd_request_get_type ())
@@ -53,12 +54,18 @@ _snapd_get_change_get_data (SnapdGetChange *self)
     return self->data;
 }
 
+void
+_snapd_get_change_set_accessories_change (SnapdGetChange *self, gboolean accessories_change)
+{
+    self->accessories_change = accessories_change;
+}
+
 static SoupMessage *
 generate_get_change_request (SnapdRequest *request)
 {
     SnapdGetChange *self = SNAPD_GET_CHANGE (request);
 
-    g_autofree gchar *path = g_strdup_printf ("http://snapd/v2/changes/%s", self->change_id);
+    g_autofree gchar *path = g_strdup_printf ("http://snapd%s/%s", self->accessories_change ? "/v2/accessories/changes" : "/v2/changes", self->change_id);
     return soup_message_new ("GET", path);
 }
 

--- a/snapd-glib/requests/snapd-get-change.h
+++ b/snapd-glib/requests/snapd-get-change.h
@@ -30,9 +30,8 @@ SnapdChange    *_snapd_get_change_get_change    (SnapdGetChange *request);
 
 JsonNode       *_snapd_get_change_get_data      (SnapdGetChange *request);
 
-void            _snapd_get_change_set_accessories_change (SnapdGetChange *request,
-                                                          gboolean        accessories_change);
-
+void            _snapd_get_change_set_api_path  (SnapdGetChange *request,
+                                                 const gchar    *api_path);
 G_END_DECLS
 
 #endif /* __SNAPD_GET_CHANGE_H__ */

--- a/snapd-glib/requests/snapd-get-change.h
+++ b/snapd-glib/requests/snapd-get-change.h
@@ -30,6 +30,9 @@ SnapdChange    *_snapd_get_change_get_change    (SnapdGetChange *request);
 
 JsonNode       *_snapd_get_change_get_data      (SnapdGetChange *request);
 
+void            _snapd_get_change_set_accessories_change (SnapdGetChange *request,
+                                                          gboolean        accessories_change);
+
 G_END_DECLS
 
 #endif /* __SNAPD_GET_CHANGE_H__ */

--- a/snapd-glib/requests/snapd-post-change.c
+++ b/snapd-glib/requests/snapd-post-change.c
@@ -19,6 +19,7 @@ struct _SnapdPostChange
     gchar *action;
     SnapdChange *change;
     JsonNode *data;
+    gboolean accessories_change;
 };
 
 G_DEFINE_TYPE (SnapdPostChange, snapd_post_change, snapd_request_get_type ())
@@ -55,12 +56,19 @@ _snapd_post_change_get_data (SnapdPostChange *self)
     return self->data;
 }
 
+void
+_snapd_post_change_set_accessories_change (SnapdPostChange *self,
+                                           gboolean accessories_change)
+{
+    self->accessories_change = accessories_change;
+}
+
 static SoupMessage *
 generate_post_change_request (SnapdRequest *request)
 {
     SnapdPostChange *self = SNAPD_POST_CHANGE (request);
 
-    g_autofree gchar *path = g_strdup_printf ("http://snapd/v2/changes/%s", self->change_id);
+    g_autofree gchar *path = g_strdup_printf ("http://snapd%s/%s", self->accessories_change ? "/v2/accessories/changes" : "/v2/changes", self->change_id);
     SoupMessage *message = soup_message_new ("POST", path);
 
     g_autoptr(JsonBuilder) builder = json_builder_new ();

--- a/snapd-glib/requests/snapd-post-change.c
+++ b/snapd-glib/requests/snapd-post-change.c
@@ -19,7 +19,7 @@ struct _SnapdPostChange
     gchar *action;
     SnapdChange *change;
     JsonNode *data;
-    gboolean accessories_change;
+    gchar *api_path;
 };
 
 G_DEFINE_TYPE (SnapdPostChange, snapd_post_change, snapd_request_get_type ())
@@ -57,10 +57,10 @@ _snapd_post_change_get_data (SnapdPostChange *self)
 }
 
 void
-_snapd_post_change_set_accessories_change (SnapdPostChange *self,
-                                           gboolean accessories_change)
+_snapd_post_change_set_api_path (SnapdPostChange *self, const gchar *api_path)
 {
-    self->accessories_change = accessories_change;
+    g_free (self->api_path);
+    self->api_path = g_strdup (api_path);
 }
 
 static SoupMessage *
@@ -68,7 +68,7 @@ generate_post_change_request (SnapdRequest *request)
 {
     SnapdPostChange *self = SNAPD_POST_CHANGE (request);
 
-    g_autofree gchar *path = g_strdup_printf ("http://snapd%s/%s", self->accessories_change ? "/v2/accessories/changes" : "/v2/changes", self->change_id);
+    g_autofree gchar *path = g_strdup_printf ("http://snapd%s/%s", self->api_path ? self->api_path : "/v2/changes", self->change_id);
     SoupMessage *message = soup_message_new ("POST", path);
 
     g_autoptr(JsonBuilder) builder = json_builder_new ();
@@ -123,6 +123,7 @@ snapd_post_change_finalize (GObject *object)
     g_clear_pointer (&self->action, g_free);
     g_clear_object (&self->change);
     g_clear_pointer (&self->data, json_node_unref);
+    g_clear_pointer (&self->api_path, g_free);
 
     G_OBJECT_CLASS (snapd_post_change_parent_class)->finalize (object);
 }

--- a/snapd-glib/requests/snapd-post-change.h
+++ b/snapd-glib/requests/snapd-post-change.h
@@ -31,8 +31,8 @@ SnapdChange     *_snapd_post_change_get_change    (SnapdPostChange *request);
 
 JsonNode        *_snapd_post_change_get_data      (SnapdPostChange *request);
 
-void             _snapd_post_change_set_accessories_change (SnapdPostChange *request,
-                                                            gboolean        accessories_change);
+void             _snapd_post_change_set_api_path  (SnapdPostChange *request,
+                                                   const gchar     *api_path);
 
 G_END_DECLS
 

--- a/snapd-glib/requests/snapd-post-change.h
+++ b/snapd-glib/requests/snapd-post-change.h
@@ -31,6 +31,9 @@ SnapdChange     *_snapd_post_change_get_change    (SnapdPostChange *request);
 
 JsonNode        *_snapd_post_change_get_data      (SnapdPostChange *request);
 
+void             _snapd_post_change_set_accessories_change (SnapdPostChange *request,
+                                                            gboolean        accessories_change);
+
 G_END_DECLS
 
 #endif /* __SNAPD_POST_CHANGE_H__ */

--- a/snapd-glib/requests/snapd-post-themes.c
+++ b/snapd-glib/requests/snapd-post-themes.c
@@ -32,6 +32,7 @@ _snapd_post_themes_new (GStrv gtk_theme_names, GStrv icon_theme_names, GStrv sou
                                                              "ready-callback-data", user_data,
                                                              "progress-callback", progress_callback,
                                                              "progress-callback-data", progress_callback_data,
+                                                             "accessories-change", TRUE,
                                                              NULL));
     self->gtk_theme_names = g_strdupv (gtk_theme_names);
     self->icon_theme_names = g_strdupv (icon_theme_names);

--- a/snapd-glib/requests/snapd-post-themes.c
+++ b/snapd-glib/requests/snapd-post-themes.c
@@ -32,7 +32,7 @@ _snapd_post_themes_new (GStrv gtk_theme_names, GStrv icon_theme_names, GStrv sou
                                                              "ready-callback-data", user_data,
                                                              "progress-callback", progress_callback,
                                                              "progress-callback-data", progress_callback_data,
-                                                             "accessories-change", TRUE,
+                                                             "change-api-path", "/v2/accessories/changes",
                                                              NULL));
     self->gtk_theme_names = g_strdupv (gtk_theme_names);
     self->icon_theme_names = g_strdupv (icon_theme_names);

--- a/snapd-glib/requests/snapd-request-async.c
+++ b/snapd-glib/requests/snapd-request-async.c
@@ -17,7 +17,7 @@ enum
 {
     PROP_PROGRESS_CALLBACK = 1,
     PROP_PROGRESS_CALLBACK_DATA,
-    PROP_ACCESSORIES_CHANGE,
+    PROP_CHANGE_API_PATH,
     PROP_LAST
 };
 
@@ -25,7 +25,7 @@ typedef struct
 {
     SnapdProgressCallback progress_callback;
     gpointer progress_callback_data;
-    gboolean accessories_change;
+    gchar *change_api_path;
 
     /* Returned change ID for this request */
     gchar *change_id;
@@ -145,7 +145,7 @@ _snapd_request_async_make_get_change_request (SnapdRequestAsync *self)
     SnapdRequestAsyncPrivate *priv = snapd_request_async_get_instance_private (self);
     SnapdGetChange *request = _snapd_get_change_new (priv->change_id, NULL, NULL, NULL);
 
-    _snapd_get_change_set_accessories_change (request, priv->accessories_change);
+    _snapd_get_change_set_api_path (request, priv->change_api_path);
     return request;
 }
 
@@ -155,7 +155,7 @@ _snapd_request_async_make_post_change_request (SnapdRequestAsync *self)
     SnapdRequestAsyncPrivate *priv = snapd_request_async_get_instance_private (self);
     SnapdPostChange *request = _snapd_post_change_new (priv->change_id, "abort", NULL, NULL, NULL);
 
-    _snapd_post_change_set_accessories_change (request, priv->accessories_change);
+    _snapd_post_change_set_api_path (request, priv->change_api_path);
     return request;
 }
 
@@ -173,8 +173,9 @@ snapd_request_async_set_property (GObject *object, guint prop_id, const GValue *
     case PROP_PROGRESS_CALLBACK_DATA:
         priv->progress_callback_data = g_value_get_pointer (value);
         break;
-    case PROP_ACCESSORIES_CHANGE:
-        priv->accessories_change = g_value_get_boolean (value);;
+    case PROP_CHANGE_API_PATH:
+        g_free (priv->change_api_path);
+        priv->change_api_path = g_value_dup_string (value);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -217,11 +218,11 @@ snapd_request_async_class_init (SnapdRequestAsyncClass *klass)
                                                           "Data for progress callback",
                                                           G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
    g_object_class_install_property (gobject_class,
-                                    PROP_ACCESSORIES_CHANGE,
-                                    g_param_spec_boolean ("accessories-change",
-                                                          "accessories-change",
-                                                          "accessories-change",
-                                                          FALSE,
+                                    PROP_CHANGE_API_PATH,
+                                    g_param_spec_string ("change-api-path",
+                                                          "change-api-path",
+                                                          "change-api-path",
+                                                          NULL,
                                                           G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
 }
 

--- a/snapd-glib/requests/snapd-request-async.c
+++ b/snapd-glib/requests/snapd-request-async.c
@@ -137,6 +137,20 @@ _snapd_request_async_report_progress (SnapdRequestAsync *self, SnapdClient *clie
     }
 }
 
+SnapdGetChange *
+_snapd_request_async_make_get_change_request (SnapdRequestAsync *self)
+{
+    SnapdRequestAsyncPrivate *priv = snapd_request_async_get_instance_private (self);
+    return _snapd_get_change_new (priv->change_id, NULL, NULL, NULL);
+}
+
+SnapdPostChange *
+_snapd_request_async_make_post_change_request (SnapdRequestAsync *self)
+{
+    SnapdRequestAsyncPrivate *priv = snapd_request_async_get_instance_private (self);
+    return _snapd_post_change_new (priv->change_id, "abort", NULL, NULL, NULL);
+}
+
 static void
 snapd_request_async_set_property (GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
 {

--- a/snapd-glib/requests/snapd-request-async.c
+++ b/snapd-glib/requests/snapd-request-async.c
@@ -17,6 +17,7 @@ enum
 {
     PROP_PROGRESS_CALLBACK = 1,
     PROP_PROGRESS_CALLBACK_DATA,
+    PROP_ACCESSORIES_CHANGE,
     PROP_LAST
 };
 
@@ -24,6 +25,7 @@ typedef struct
 {
     SnapdProgressCallback progress_callback;
     gpointer progress_callback_data;
+    gboolean accessories_change;
 
     /* Returned change ID for this request */
     gchar *change_id;
@@ -141,14 +143,20 @@ SnapdGetChange *
 _snapd_request_async_make_get_change_request (SnapdRequestAsync *self)
 {
     SnapdRequestAsyncPrivate *priv = snapd_request_async_get_instance_private (self);
-    return _snapd_get_change_new (priv->change_id, NULL, NULL, NULL);
+    SnapdGetChange *request = _snapd_get_change_new (priv->change_id, NULL, NULL, NULL);
+
+    _snapd_get_change_set_accessories_change (request, priv->accessories_change);
+    return request;
 }
 
 SnapdPostChange *
 _snapd_request_async_make_post_change_request (SnapdRequestAsync *self)
 {
     SnapdRequestAsyncPrivate *priv = snapd_request_async_get_instance_private (self);
-    return _snapd_post_change_new (priv->change_id, "abort", NULL, NULL, NULL);
+    SnapdPostChange *request = _snapd_post_change_new (priv->change_id, "abort", NULL, NULL, NULL);
+
+    _snapd_post_change_set_accessories_change (request, priv->accessories_change);
+    return request;
 }
 
 static void
@@ -164,6 +172,9 @@ snapd_request_async_set_property (GObject *object, guint prop_id, const GValue *
         break;
     case PROP_PROGRESS_CALLBACK_DATA:
         priv->progress_callback_data = g_value_get_pointer (value);
+        break;
+    case PROP_ACCESSORIES_CHANGE:
+        priv->accessories_change = g_value_get_boolean (value);;
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -204,6 +215,13 @@ snapd_request_async_class_init (SnapdRequestAsyncClass *klass)
                                     g_param_spec_pointer ("progress-callback-data",
                                                           "progress-callback-data",
                                                           "Data for progress callback",
+                                                          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
+   g_object_class_install_property (gobject_class,
+                                    PROP_ACCESSORIES_CHANGE,
+                                    g_param_spec_boolean ("accessories-change",
+                                                          "accessories-change",
+                                                          "accessories-change",
+                                                          FALSE,
                                                           G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY));
 }
 

--- a/snapd-glib/requests/snapd-request-async.h
+++ b/snapd-glib/requests/snapd-request-async.h
@@ -16,6 +16,8 @@
 #include "snapd-request.h"
 #include "snapd-change.h"
 #include "snapd-client.h"
+#include "snapd-get-change.h"
+#include "snapd-post-change.h"
 
 G_BEGIN_DECLS
 
@@ -37,6 +39,10 @@ gboolean     _snapd_request_async_parse_result    (SnapdRequestAsync *request,
 void         _snapd_request_async_report_progress (SnapdRequestAsync *request,
                                                    SnapdClient       *client,
                                                    SnapdChange       *change);
+
+SnapdGetChange  *_snapd_request_async_make_get_change_request  (SnapdRequestAsync *request);
+
+SnapdPostChange *_snapd_request_async_make_post_change_request (SnapdRequestAsync *request);
 
 G_END_DECLS
 

--- a/snapd-glib/snapd-client.c
+++ b/snapd-glib/snapd-client.c
@@ -227,7 +227,7 @@ async_poll_cb (gpointer data)
 {
     RequestData *d = data;
 
-    g_autoptr(SnapdGetChange) change_request = _snapd_get_change_new (_snapd_request_async_get_change_id (SNAPD_REQUEST_ASYNC (d->request)), NULL, NULL, NULL);
+    g_autoptr(SnapdGetChange) change_request = _snapd_request_async_make_get_change_request (SNAPD_REQUEST_ASYNC (d->request));
     send_request (d->client, SNAPD_REQUEST (change_request));
 
     if (d->poll_source != NULL)
@@ -371,7 +371,7 @@ send_cancel (SnapdClient *self, SnapdRequestAsync *request)
     if (change_request != NULL)
         return;
 
-    change_request = _snapd_post_change_new (_snapd_request_async_get_change_id (request), "abort", NULL, NULL, NULL);
+    change_request = _snapd_request_async_make_post_change_request (request);
     send_request (self, SNAPD_REQUEST (change_request));
 }
 

--- a/tests/mock-snapd.c
+++ b/tests/mock-snapd.c
@@ -4745,6 +4745,8 @@ handle_request (SoupServer        *server,
         handle_download (self, message);
     else if (strcmp (path, "/v2/accessories/themes") == 0)
         handle_themes (self, message);
+    else if (g_str_has_prefix (path, "/v2/accessories/changes/"))
+        handle_change (self, message, path + strlen ("/v2/accessories/changes/"));
     else
         send_error_not_found (self, message, "not found", NULL);
 }


### PR DESCRIPTION
This PR is intended to help fix https://github.com/snapcore/snapd-desktop-integration/issues/7, together with https://github.com/snapcore/snapd/pull/11450 on the snapd side. The snapd side has been merged and cherry-picked into the 2.55 branch.

The themes status API was intended to be usable from the restricted REST API available over `/run/snapd-snap.socket` to snaps that plug snap-themes-control. While the main requests function, we didn't expose a way to track the status of async tasks such as the one created by `snapd_client_install_themes_*`.

Rather than exposing the entire changes interface, a subset of it is available at `/v2/accessories/changes/NNN`, and will only provide details of changes initated through the themes interface.

This snapd-glib change makes SnapdRequestAsync responsible for creating the requests used to check the status of its change. A SnapdRequestAsync can then be marked as using the `/v2/accessories/changes` endpoint if appropriate. The SnapdPostThemes request does so.

As far as compatibility concerns go, this only changes the behaviour of the `snapd_client_install_themes_*` functions. They currently have only one user in the form of snapd-desktop-integration, which is broken without this change. So I think this should be a relatively safe change to merge.