### PR TITLE
Replace soup_uri_encode with g_string_append_uri_escaped

### DIFF
--- a/snapd-glib/requests/snapd-get-apps.c
+++ b/snapd-glib/requests/snapd-get-apps.c
@@ -55,12 +55,18 @@ generate_get_apps_request (SnapdRequest *request)
 
     g_autoptr(GPtrArray) query_attributes = g_ptr_array_new_with_free_func (g_free);
     if (self->select != NULL) {
-        g_autofree gchar *escaped = soup_uri_encode (self->select, NULL);
-        g_ptr_array_add (query_attributes, g_strdup_printf ("select=%s", escaped));
+        g_autoptr(GString) attr = g_string_new("select=");
+        g_string_append_uri_escaped (attr, self->select, NULL, TRUE);
+        g_ptr_array_add (query_attributes, g_strdup (attr->str));
     }
     if (self->snaps != NULL) {
-        g_autofree gchar *snaps_list = g_strjoinv (",", self->snaps);
-        g_ptr_array_add (query_attributes, g_strdup_printf ("names=%s", snaps_list));
+        g_autoptr(GString) attr = g_string_new("names=");
+        for (guint i = 0; self->snaps[i] != NULL; i++) {
+            if (i != 0)
+                g_string_append (attr, ",");
+            g_string_append_uri_escaped (attr, self->snaps[i], NULL, TRUE);
+        }
+        g_ptr_array_add (query_attributes, g_strdup (attr->str));
     }
 
     g_autoptr(GString) path = g_string_new ("http://snapd/v2/apps");

--- a/snapd-glib/requests/snapd-get-assertions.c
+++ b/snapd-glib/requests/snapd-get-assertions.c
@@ -48,10 +48,10 @@ generate_get_assertions_request (SnapdRequest *request)
 {
     SnapdGetAssertions *self = SNAPD_GET_ASSERTIONS (request);
 
-    g_autofree gchar *escaped = soup_uri_encode (self->type, NULL);
-    g_autofree gchar *path = g_strdup_printf ("http://snapd/v2/assertions/%s", escaped);
+    g_autoptr(GString) path = g_string_new ("http://snapd/v2/assertions/");
+    g_string_append_uri_escaped (path, self->type, NULL, TRUE);
 
-    return soup_message_new ("GET", path);
+    return soup_message_new ("GET", path->str);
 }
 
 static gboolean

--- a/snapd-glib/requests/snapd-get-changes.c
+++ b/snapd-glib/requests/snapd-get-changes.c
@@ -49,12 +49,14 @@ generate_get_changes_request (SnapdRequest *request)
 
     g_autoptr(GPtrArray) query_attributes = g_ptr_array_new_with_free_func (g_free);
     if (self->select != NULL) {
-        g_autofree gchar *escaped = soup_uri_encode (self->select, NULL);
-        g_ptr_array_add (query_attributes, g_strdup_printf ("select=%s", escaped));
+        g_autoptr(GString) attr = g_string_new ("select=");
+        g_string_append_uri_escaped (attr, self->select, NULL, TRUE);
+        g_ptr_array_add (query_attributes, g_strdup (attr->str));
     }
     if (self->snap_name != NULL) {
-        g_autofree gchar *escaped = soup_uri_encode (self->snap_name, NULL);
-        g_ptr_array_add (query_attributes, g_strdup_printf ("for=%s", escaped));
+        g_autoptr(GString) attr = g_string_new ("for=");
+        g_string_append_uri_escaped (attr, self->snap_name, NULL, TRUE);
+        g_ptr_array_add (query_attributes, g_strdup (attr->str));
     }
 
     g_autoptr(GString) path = g_string_new ("http://snapd/v2/changes");

--- a/snapd-glib/requests/snapd-get-find.c
+++ b/snapd-glib/requests/snapd-get-find.c
@@ -100,28 +100,34 @@ generate_get_find_request (SnapdRequest *request)
 
     g_autoptr(GPtrArray) query_attributes = g_ptr_array_new_with_free_func (g_free);
     if (self->common_id != NULL) {
-        g_autofree gchar *escaped = soup_uri_encode (self->common_id, NULL);
-        g_ptr_array_add (query_attributes, g_strdup_printf ("common-id=%s", escaped));
+        g_autoptr(GString) attr = g_string_new ("common-id=");
+        g_string_append_uri_escaped (attr, self->common_id, NULL, TRUE);
+        g_ptr_array_add (query_attributes, g_strdup (attr->str));
     }
     if (self->query != NULL) {
-        g_autofree gchar *escaped = soup_uri_encode (self->query, NULL);
-        g_ptr_array_add (query_attributes, g_strdup_printf ("q=%s", escaped));
+        g_autoptr(GString) attr = g_string_new ("q=");
+        g_string_append_uri_escaped (attr, self->query, NULL, TRUE);
+        g_ptr_array_add (query_attributes, g_strdup (attr->str));
     }
     if (self->name != NULL) {
-        g_autofree gchar *escaped = soup_uri_encode (self->name, NULL);
-        g_ptr_array_add (query_attributes, g_strdup_printf ("name=%s", escaped));
+        g_autoptr(GString) attr = g_string_new ("name=");
+        g_string_append_uri_escaped (attr, self->name, NULL, TRUE);
+        g_ptr_array_add (query_attributes, g_strdup (attr->str));
     }
     if (self->select != NULL) {
-        g_autofree gchar *escaped = soup_uri_encode (self->select, NULL);
-        g_ptr_array_add (query_attributes, g_strdup_printf ("select=%s", escaped));
+        g_autoptr(GString) attr = g_string_new ("select=");
+        g_string_append_uri_escaped (attr, self->select, NULL, TRUE);
+        g_ptr_array_add (query_attributes, g_strdup (attr->str));
     }
     if (self->section != NULL) {
-        g_autofree gchar *escaped = soup_uri_encode (self->section, NULL);
-        g_ptr_array_add (query_attributes, g_strdup_printf ("section=%s", escaped));
+        g_autoptr(GString) attr = g_string_new ("section=");
+        g_string_append_uri_escaped (attr, self->section, NULL, TRUE);
+        g_ptr_array_add (query_attributes, g_strdup (attr->str));
     }
     if (self->scope != NULL) {
-        g_autofree gchar *escaped = soup_uri_encode (self->scope, NULL);
-        g_ptr_array_add (query_attributes, g_strdup_printf ("scope=%s", escaped));
+        g_autoptr(GString) attr = g_string_new ("scope=");
+        g_string_append_uri_escaped (attr, self->scope, NULL, TRUE);
+        g_ptr_array_add (query_attributes, g_strdup (attr->str));
     }
 
     g_autoptr(GString) path = g_string_new ("http://snapd/v2/find");

--- a/snapd-glib/requests/snapd-get-icon.c
+++ b/snapd-glib/requests/snapd-get-icon.c
@@ -45,10 +45,11 @@ generate_get_icon_request (SnapdRequest *request)
 {
     SnapdGetIcon *self = SNAPD_GET_ICON (request);
 
-    g_autofree gchar *escaped = soup_uri_encode (self->name, NULL);
-    g_autofree gchar *path = g_strdup_printf ("http://snapd/v2/icons/%s/icon", escaped);
+    g_autoptr(GString) path = g_string_new ("http://snapd/v2/icons/");
+    g_string_append_uri_escaped (path, self->name, NULL, TRUE);
+    g_string_append (path, "/icon");
 
-    return soup_message_new ("GET", path);
+    return soup_message_new ("GET", path->str);
 }
 
 static gboolean

--- a/snapd-glib/requests/snapd-get-snap-conf.c
+++ b/snapd-glib/requests/snapd-get-snap-conf.c
@@ -53,9 +53,9 @@ generate_get_snap_conf_request (SnapdRequest *request)
         g_ptr_array_add (query_attributes, g_strdup_printf ("keys=%s", keys_list));
     }
 
-    g_autoptr(GString) path = g_string_new ("");
-    g_autofree gchar *escaped = soup_uri_encode (self->name, NULL);
-    g_string_append_printf (path, "http://snapd/v2/snaps/%s/conf", escaped);
+    g_autoptr(GString) path = g_string_new ("http://snapd/v2/snaps/");
+    g_string_append_uri_escaped (path, self->name, NULL, TRUE);
+    g_string_append (path, "/conf");
     if (query_attributes->len > 0) {
         g_string_append_c (path, '?');
         for (guint i = 0; i < query_attributes->len; i++) {

--- a/snapd-glib/requests/snapd-get-snap.c
+++ b/snapd-glib/requests/snapd-get-snap.c
@@ -44,10 +44,10 @@ generate_get_snap_request (SnapdRequest *request)
 {
     SnapdGetSnap *self = SNAPD_GET_SNAP (request);
 
-    g_autofree gchar *escaped = soup_uri_encode (self->name, NULL);
-    g_autofree gchar *path = g_strdup_printf ("http://snapd/v2/snaps/%s", escaped);
+    g_autoptr(GString) path = g_string_new ("http://snapd/v2/snaps/");
+    g_string_append_uri_escaped (path, self->name, NULL, TRUE);
 
-    return soup_message_new ("GET", path);
+    return soup_message_new ("GET", path->str);
 }
 
 static gboolean

--- a/snapd-glib/requests/snapd-get-themes.c
+++ b/snapd-glib/requests/snapd-get-themes.c
@@ -64,18 +64,14 @@ _snapd_get_themes_get_sound_theme_status (SnapdGetThemes *self)
 static void
 add_theme_names (GString *path, gboolean *first_param, const char *theme_type, GStrv theme_names)
 {
-    char *const *name;
-
     if (theme_names == NULL)
         return;
 
-    for (name = theme_names; *name != NULL; name++) {
-        g_autofree gchar *escaped = soup_uri_encode (*name, NULL);
-
+    for (gchar * const *name = theme_names; *name != NULL; name++) {
         g_string_append_c (path, *first_param ? '?' : '&');
         *first_param = FALSE;
         g_string_append (path, theme_type);
-        g_string_append (path, escaped);
+        g_string_append_uri_escaped (path, *name, NULL, TRUE);
     }
 }
 

--- a/snapd-glib/requests/snapd-post-snap.c
+++ b/snapd-glib/requests/snapd-post-snap.c
@@ -94,9 +94,9 @@ generate_post_snap_request (SnapdRequest *request)
 {
     SnapdPostSnap *self = SNAPD_POST_SNAP (request);
 
-    g_autofree gchar *escaped = soup_uri_encode (self->name, NULL);
-    g_autofree gchar *path = g_strdup_printf ("http://snapd/v2/snaps/%s", escaped);
-    SoupMessage *message = soup_message_new ("POST", path);
+    g_autoptr(GString) path = g_string_new ("http://snapd/v2/snaps/");
+    g_string_append_uri_escaped (path, self->name, NULL, TRUE);
+    SoupMessage *message = soup_message_new ("POST", path->str);
 
     g_autoptr(JsonBuilder) builder = json_builder_new ();
     json_builder_begin_object (builder);

--- a/snapd-glib/requests/snapd-put-snap-conf.c
+++ b/snapd-glib/requests/snapd-put-snap-conf.c
@@ -39,9 +39,10 @@ generate_put_snap_conf_request (SnapdRequest *request)
 {
     SnapdPutSnapConf *self = SNAPD_PUT_SNAP_CONF (request);
 
-    g_autofree gchar *escaped = soup_uri_encode (self->name, NULL);
-    g_autofree gchar *path = g_strdup_printf ("http://snapd/v2/snaps/%s/conf", escaped);
-    SoupMessage *message = soup_message_new ("PUT", path);
+    g_autoptr(GString) path = g_string_new ("http://snapd/v2/snaps/");
+    g_string_append_uri_escaped (path, self->name, NULL, TRUE);
+    g_string_append (path, "/conf");
+    SoupMessage *message = soup_message_new ("PUT", path->str);
 
     g_autoptr(JsonBuilder) builder = json_builder_new ();
     json_builder_begin_object (builder);


### PR DESCRIPTION
This method is removed in libsoup3, and is unnecessary as there is an equivalent in GLib.