### PR TITLE
Fix gobject-introspection parameter name

### DIFF
--- a/snapd-glib/snapd-alias.c
+++ b/snapd-glib/snapd-alias.c
@@ -58,7 +58,7 @@ G_DEFINE_TYPE (SnapdAlias, snapd_alias, G_TYPE_OBJECT)
 
 /**
  * snapd_alias_get_app:
- * @alias: a #SnapdAlias.
+ * @self: a #SnapdAlias.
  *
  * Get the app this is an alias for.
  *
@@ -76,7 +76,7 @@ snapd_alias_get_app (SnapdAlias *self)
 
 /**
  * snapd_alias_get_app_auto:
- * @alias: a #SnapdAlias.
+ * @self: a #SnapdAlias.
  *
  * Get the app this alias has been automatically set to (status is %SNAPD_ALIAS_STATUS_AUTO).
  * Can be overridden when status is %SNAPD_ALIAS_STATUS_MANUAL.
@@ -94,7 +94,7 @@ snapd_alias_get_app_auto (SnapdAlias *self)
 
 /**
  * snapd_alias_get_app_manual:
- * @alias: a #SnapdAlias.
+ * @self: a #SnapdAlias.
  *
  * Get the app this alias has been manually set to (status is %SNAPD_ALIAS_STATUS_MANUAL).
  * This overrides the app from snapd_alias_get_app_auto().
@@ -112,7 +112,7 @@ snapd_alias_get_app_manual (SnapdAlias *self)
 
 /**
  * snapd_alias_get_command:
- * @alias: a #SnapdAlias.
+ * @self: a #SnapdAlias.
  *
  * Get the command this alias runs.
  *
@@ -129,7 +129,7 @@ snapd_alias_get_command (SnapdAlias *self)
 
 /**
  * snapd_alias_get_name:
- * @alias: a #SnapdAlias.
+ * @self: a #SnapdAlias.
  *
  * Get the name of this alias.
  *
@@ -146,7 +146,7 @@ snapd_alias_get_name (SnapdAlias *self)
 
 /**
  * snapd_alias_get_snap:
- * @alias: a #SnapdAlias.
+ * @self: a #SnapdAlias.
  *
  * Get the snap this alias is for.
  *
@@ -163,7 +163,7 @@ snapd_alias_get_snap (SnapdAlias *self)
 
 /**
  * snapd_alias_get_status:
- * @alias: a #SnapdAlias.
+ * @self: a #SnapdAlias.
  *
  * Get the status of this alias.
  *

--- a/snapd-glib/snapd-app.c
+++ b/snapd-glib/snapd-app.c
@@ -60,7 +60,7 @@ G_DEFINE_TYPE (SnapdApp, snapd_app, G_TYPE_OBJECT)
 
 /**
  * snapd_app_get_name:
- * @app: a #SnapdApp.
+ * @self: a #SnapdApp.
  *
  * Get the name of this app.
  *
@@ -77,7 +77,7 @@ snapd_app_get_name (SnapdApp *self)
 
 /**
  * snapd_app_get_active:
- * @app: a #SnapdApp.
+ * @self: a #SnapdApp.
  *
  * Get if this service is active.
  *
@@ -94,7 +94,7 @@ snapd_app_get_active (SnapdApp *self)
 
 /**
  * snapd_app_get_aliases:
- * @app: a #SnapdApp.
+ * @self: a #SnapdApp.
  *
  * Get the aliases for this app.
  *
@@ -112,7 +112,7 @@ snapd_app_get_aliases (SnapdApp *self)
 
 /**
  * snapd_app_get_common_id:
- * @app: a #SnapdApp.
+ * @self: a #SnapdApp.
  *
  * Get the common ID associated with this app.
  *
@@ -129,7 +129,7 @@ snapd_app_get_common_id (SnapdApp *self)
 
 /**
  * snapd_app_get_daemon_type:
- * @app: a #SnapdApp.
+ * @self: a #SnapdApp.
  *
  * Get the daemon type for this app.
  *
@@ -146,7 +146,7 @@ snapd_app_get_daemon_type (SnapdApp *self)
 
 /**
  * snapd_app_get_desktop_file:
- * @app: a #SnapdApp.
+ * @self: a #SnapdApp.
  *
  * Get the path to the desktop file for this app.
  *
@@ -163,7 +163,7 @@ snapd_app_get_desktop_file (SnapdApp *self)
 
 /**
  * snapd_app_get_enabled:
- * @app: a #SnapdApp.
+ * @self: a #SnapdApp.
  *
  * Get if this service is enabled.
  *
@@ -180,7 +180,7 @@ snapd_app_get_enabled (SnapdApp *self)
 
 /**
  * snapd_app_get_snap:
- * @app: a #SnapdApp.
+ * @self: a #SnapdApp.
  *
  * Get the snap this app is associated with.
  *

--- a/snapd-glib/snapd-assertion.c
+++ b/snapd-glib/snapd-assertion.c
@@ -113,7 +113,7 @@ get_header (const gchar *content, gsize *offset, gsize *name_start, gsize *name_
 
 /**
  * snapd_assertion_get_headers:
- * @assertion: a #SnapdAssertion.
+ * @self: a #SnapdAssertion.
  *
  * Get the headers provided by this assertion.
  *
@@ -145,7 +145,7 @@ snapd_assertion_get_headers (SnapdAssertion *self)
 
 /**
  * snapd_assertion_get_header:
- * @assertion: a #SnapdAssertion.
+ * @self: a #SnapdAssertion.
  * @name: name of the header.
  *
  * Get a header from an assertion.
@@ -201,7 +201,7 @@ get_body_length (SnapdAssertion *self)
 
 /**
  * snapd_assertion_get_body:
- * @assertion: a #SnapdAssertion.
+ * @self: a #SnapdAssertion.
  *
  * Get the body of the assertion.
  *
@@ -223,7 +223,7 @@ snapd_assertion_get_body (SnapdAssertion *self)
 
 /**
  * snapd_assertion_get_signature:
- * @assertion: a #SnapdAssertion.
+ * @self: a #SnapdAssertion.
  *
  * Get the signature of the assertion.
  *

--- a/snapd-glib/snapd-auth-data.c
+++ b/snapd-glib/snapd-auth-data.c
@@ -74,7 +74,7 @@ snapd_auth_data_new (const gchar *macaroon, GStrv discharges)
 
 /**
  * snapd_auth_data_get_macaroon:
- * @auth_data: a #SnapdAuthData.
+ * @self: a #SnapdAuthData.
  *
  * Get the Macaroon that this authorization uses.
  *
@@ -91,7 +91,7 @@ snapd_auth_data_get_macaroon (SnapdAuthData *self)
 
 /**
  * snapd_auth_data_get_discharges:
- * @auth_data: a #SnapdAuthData.
+ * @self: a #SnapdAuthData.
  *
  * Get the discharges that this authorization uses.
  *

--- a/snapd-glib/snapd-category-details.c
+++ b/snapd-glib/snapd-category-details.c
@@ -44,7 +44,7 @@ G_DEFINE_TYPE (SnapdCategoryDetails, snapd_category_details, G_TYPE_OBJECT)
 
 /**
  * snapd_category_details_get_name:
- * @category_details: a #SnapdCategoryDetails.
+ * @self: a #SnapdCategoryDetails.
  *
  * Get the name of this category, e.g. "social".
  *

--- a/snapd-glib/snapd-category.c
+++ b/snapd-glib/snapd-category.c
@@ -47,7 +47,7 @@ G_DEFINE_TYPE (SnapdCategory, snapd_category, G_TYPE_OBJECT)
 
 /**
  * snapd_category_get_featured:
- * @category: a #SnapdCategory.
+ * @self: a #SnapdCategory.
  *
  * Get if this snap is featured in this category.
  *
@@ -64,7 +64,7 @@ snapd_category_get_featured (SnapdCategory *self)
 
 /**
  * snapd_category_get_name:
- * @category: a #SnapdCategory.
+ * @self: a #SnapdCategory.
  *
  * Get the name of this category, e.g. "social".
  *

--- a/snapd-glib/snapd-change.c
+++ b/snapd-glib/snapd-change.c
@@ -61,7 +61,7 @@ G_DEFINE_TYPE (SnapdChange, snapd_change, G_TYPE_OBJECT)
 
 /**
  * snapd_change_get_id:
- * @change: a #SnapdChange.
+ * @self: a #SnapdChange.
  *
  * Get the unique ID for this change.
  *
@@ -78,7 +78,7 @@ snapd_change_get_id (SnapdChange *self)
 
 /**
  * snapd_change_get_kind:
- * @change: a #SnapdChange.
+ * @self: a #SnapdChange.
  *
  * Gets the kind of change this is.
  *
@@ -95,7 +95,7 @@ snapd_change_get_kind (SnapdChange *self)
 
 /**
  * snapd_change_get_summary:
- * @change: a #SnapdChange.
+ * @self: a #SnapdChange.
  *
  * Get a human readable description of the change.
  *
@@ -112,7 +112,7 @@ snapd_change_get_summary (SnapdChange *self)
 
 /**
  * snapd_change_get_status:
- * @change: a #SnapdChange.
+ * @self: a #SnapdChange.
  *
  * Get the status of the change.
  *
@@ -129,7 +129,7 @@ snapd_change_get_status (SnapdChange *self)
 
 /**
  * snapd_change_get_tasks:
- * @change: a #SnapdChange.
+ * @self: a #SnapdChange.
  *
  * Get the tasks that are in this change.
  *
@@ -146,7 +146,7 @@ snapd_change_get_tasks (SnapdChange *self)
 
 /**
  * snapd_change_get_ready:
- * @change: a #SnapdChange.
+ * @self: a #SnapdChange.
  *
  * Get if this change is completed.
  *
@@ -163,7 +163,7 @@ snapd_change_get_ready (SnapdChange *self)
 
 /**
  * snapd_change_get_spawn_time:
- * @change: a #SnapdChange.
+ * @self: a #SnapdChange.
  *
  * Get the time this change started.
  *
@@ -180,7 +180,7 @@ snapd_change_get_spawn_time (SnapdChange *self)
 
 /**
  * snapd_change_get_ready_time:
- * @change: a #SnapdChange.
+ * @self: a #SnapdChange.
  *
  * Get the time this task completed or %NULL if not yet completed.
  *
@@ -197,7 +197,7 @@ snapd_change_get_ready_time (SnapdChange *self)
 
 /**
  * snapd_change_get_error:
- * @change: a #SnapdChange.
+ * @self: a #SnapdChange.
  *
  * Gets the error string associated with this change.
  *

--- a/snapd-glib/snapd-channel.c
+++ b/snapd-glib/snapd-channel.c
@@ -60,7 +60,7 @@ G_DEFINE_TYPE (SnapdChannel, snapd_channel, G_TYPE_OBJECT)
 
 /**
  * snapd_channel_get_branch:
- * @channel: a #SnapdChannel.
+ * @self: a #SnapdChannel.
  *
  * Get the branch this channel is tracking.
  *
@@ -77,7 +77,7 @@ snapd_channel_get_branch (SnapdChannel *self)
 
 /**
  * snapd_channel_get_confinement:
- * @channel: a #SnapdChannel.
+ * @self: a #SnapdChannel.
  *
  * Get the confinement this snap is using, e.g. %SNAPD_CONFINEMENT_STRICT.
  *
@@ -94,7 +94,7 @@ snapd_channel_get_confinement (SnapdChannel *self)
 
 /**
  * snapd_channel_get_epoch:
- * @channel: a #SnapdChannel.
+ * @self: a #SnapdChannel.
  *
  * Get the epoch used on this channel, e.g. "1".
  *
@@ -111,7 +111,7 @@ snapd_channel_get_epoch (SnapdChannel *self)
 
 /**
  * snapd_channel_get_name:
- * @channel: a #SnapdChannel.
+ * @self: a #SnapdChannel.
  *
  * Get the name of this channel, e.g. "stable".
  *
@@ -140,7 +140,7 @@ snapd_channel_get_name (SnapdChannel *self)
 
 /**
  * snapd_channel_get_released_at:
- * @channel: a #SnapdChannel.
+ * @self: a #SnapdChannel.
  *
  * Get the date this revision was released into the channel or %NULL if unknown.
  *
@@ -157,7 +157,7 @@ snapd_channel_get_released_at (SnapdChannel *self)
 
 /**
  * snapd_channel_get_revision:
- * @channel: a #SnapdChannel.
+ * @self: a #SnapdChannel.
  *
  * Get the revision for this snap. The format of the string is undefined.
  * See also snapd_channel_get_version().
@@ -175,7 +175,7 @@ snapd_channel_get_revision (SnapdChannel *self)
 
 /**
  * snapd_channel_get_risk:
- * @channel: a #SnapdChannel.
+ * @self: a #SnapdChannel.
  *
  * Get the risk this channel is on, one of `stable`, `candidate`, `beta` or `edge`.
  *
@@ -192,7 +192,7 @@ snapd_channel_get_risk (SnapdChannel *self)
 
 /**
  * snapd_channel_get_size:
- * @channel: a #SnapdChannel.
+ * @self: a #SnapdChannel.
  *
  * Get the download size of this snap.
  *
@@ -209,7 +209,7 @@ snapd_channel_get_size (SnapdChannel *self)
 
 /**
  * snapd_channel_get_track:
- * @channel: a #SnapdChannel.
+ * @self: a #SnapdChannel.
  *
  * Get the track this channel is on.
  *
@@ -226,7 +226,7 @@ snapd_channel_get_track (SnapdChannel *self)
 
 /**
  * snapd_channel_get_version:
- * @channel: a #SnapdChannel.
+ * @self: a #SnapdChannel.
  *
  * Get the version for this snap. The format of the string is undefined.
  * See also snapd_channel_get_revision().

--- a/snapd-glib/snapd-client-sync.c
+++ b/snapd-glib/snapd-client-sync.c
@@ -53,7 +53,7 @@ sync_cb (GObject *object, GAsyncResult *result, gpointer user_data)
 
 /**
  * snapd_client_connect_sync:
- * @client: a #SnapdClient
+ * @self: a #SnapdClient
  * @cancellable: (allow-none): a #GCancellable or %NULL
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -72,7 +72,7 @@ snapd_client_connect_sync (SnapdClient *self,
 
 /**
  * snapd_client_login_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @email: email address to log in with.
  * @password: password to log in with.
  * @otp: (allow-none): response to one-time password challenge.
@@ -109,7 +109,7 @@ G_GNUC_END_IGNORE_DEPRECATIONS
 
 /**
  * snapd_client_login2_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @email: email address to log in with.
  * @password: password to log in with.
  * @otp: (allow-none): response to one-time password challenge.
@@ -141,7 +141,7 @@ snapd_client_login2_sync (SnapdClient *self,
 
 /**
  * snapd_client_logout_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @id: login ID to use.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
@@ -169,7 +169,7 @@ snapd_client_logout_sync (SnapdClient *self,
 
 /**
  * snapd_client_get_changes_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @filter: changes to filter on.
  * @snap_name: (allow-none): name of snap to filter on or %NULL for changes for any snap.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -198,7 +198,7 @@ snapd_client_get_changes_sync (SnapdClient *self,
 
 /**
  * snapd_client_get_change_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @id: a change ID to get information on.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
@@ -227,7 +227,7 @@ snapd_client_get_change_sync (SnapdClient *self,
 
 /**
  * snapd_client_abort_change_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @id: a change ID to abort.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
@@ -256,7 +256,7 @@ snapd_client_abort_change_sync (SnapdClient *self,
 
 /**
  * snapd_client_get_system_information_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -283,7 +283,7 @@ snapd_client_get_system_information_sync (SnapdClient *self,
 
 /**
  * snapd_client_list_one_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to get.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
@@ -305,7 +305,7 @@ snapd_client_list_one_sync (SnapdClient *self,
 
 /**
  * snapd_client_get_snap_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to get.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
@@ -332,7 +332,7 @@ snapd_client_get_snap_sync (SnapdClient *self,
 
 /**
  * snapd_client_get_snap_conf_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to get configuration from.
  * @keys: (allow-none): keys to returns or %NULL to return all.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -362,7 +362,7 @@ snapd_client_get_snap_conf_sync (SnapdClient *self,
 
 /**
  * snapd_client_set_snap_conf_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to set configuration for.
  * @key_values: (element-type utf8 GVariant): Keys to set.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -393,7 +393,7 @@ snapd_client_set_snap_conf_sync (SnapdClient *self,
 
 /**
  * snapd_client_get_apps_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdGetAppsFlags to control what results are returned.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
@@ -415,7 +415,7 @@ snapd_client_get_apps_sync (SnapdClient *self,
 
 /**
  * snapd_client_get_apps2_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdGetAppsFlags to control what results are returned.
  * @snaps: (allow-none): A list of snap names to return results for. If %NULL or empty then apps for all installed snaps are returned.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -444,7 +444,7 @@ snapd_client_get_apps2_sync (SnapdClient *self,
 
 /**
  * snapd_client_get_icon_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to get icon for.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
@@ -471,7 +471,7 @@ snapd_client_get_icon_sync (SnapdClient *self,
 
 /**
  * snapd_client_list_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -502,7 +502,7 @@ G_GNUC_END_IGNORE_DEPRECATIONS
 
 /**
  * snapd_client_get_snaps_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdGetSnapsFlags to control what results are returned.
  * @names: (allow-none): A list of snap names or %NULL.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -535,7 +535,7 @@ snapd_client_get_snaps_sync (SnapdClient *self,
 
 /**
  * snapd_client_get_assertions_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @type: assertion type to get.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
@@ -562,7 +562,7 @@ snapd_client_get_assertions_sync (SnapdClient *self,
 
 /**
  * snapd_client_add_assertions_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @assertions: assertions to add.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
@@ -590,7 +590,7 @@ snapd_client_add_assertions_sync (SnapdClient *self,
 
 /**
  * snapd_client_get_interfaces_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @plugs: (out) (allow-none) (transfer container) (element-type SnapdPlug): the location to store the array of #SnapdPlug or %NULL.
  * @slots: (out) (allow-none) (transfer container) (element-type SnapdSlot): the location to store the array of #SnapdSlot or %NULL.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -623,7 +623,7 @@ G_GNUC_END_IGNORE_DEPRECATIONS
 
 /**
  * snapd_client_get_interfaces2_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdGetInterfacesFlags to control what information is returned about the interfaces.
  * @names: (allow-none) (array zero-terminated=1): a null-terminated array of interface names or %NULL.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -652,7 +652,7 @@ snapd_client_get_interfaces2_sync (SnapdClient *self,
 
 /**
  * snapd_client_get_connections_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @established: (out) (allow-none) (transfer container) (element-type SnapdConnection): the location to store the array of connections or %NULL.
  * @undesired: (out) (allow-none) (transfer container) (element-type SnapdConnection): the location to store the array of auto-connected connections that have been manually disconnected or %NULL.
  * @plugs: (out) (allow-none) (transfer container) (element-type SnapdPlug): the location to store the array of #SnapdPlug or %NULL.
@@ -688,7 +688,7 @@ G_GNUC_END_IGNORE_DEPRECATIONS
 
 /**
  * snapd_client_get_connections2_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdGetConnectionsFlags to control what results are returned.
  * @snap: (allow-none): the name of the snap to get connections for or %NULL for all snaps.
  * @interface: (allow-none): the name of the interface to get connections for or %NULL for all interfaces.
@@ -723,7 +723,7 @@ snapd_client_get_connections2_sync (SnapdClient *self,
 
 /**
  * snapd_client_connect_interface_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @plug_snap: name of snap containing plug.
  * @plug_name: name of plug to connect.
  * @slot_snap: name of snap containing socket.
@@ -758,7 +758,7 @@ snapd_client_connect_interface_sync (SnapdClient *self,
 
 /**
  * snapd_client_disconnect_interface_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @plug_snap: name of snap containing plug.
  * @plug_name: name of plug to disconnect.
  * @slot_snap: name of snap containing socket.
@@ -792,7 +792,7 @@ snapd_client_disconnect_interface_sync (SnapdClient *self,
 
 /**
  * snapd_client_find_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdFindFlags to control how the find is performed.
  * @query: (allow-none): query string to send or %NULL to return featured snaps.
  * @suggested_currency: (out) (allow-none): location to store the ISO 4217 currency that is suggested to purchase with.
@@ -816,7 +816,7 @@ snapd_client_find_sync (SnapdClient *self,
 
 /**
  * snapd_client_find_section_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdFindFlags to control how the find is performed.
  * @section: (allow-none): store section to search in or %NULL to search in all sections.
  * @query: (allow-none): query string to send or %NULL to get all snaps from the given section.
@@ -852,7 +852,7 @@ G_GNUC_END_IGNORE_DEPRECATIONS
 
 /**
  * snapd_client_find_category_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdFindFlags to control how the find is performed.
  * @category: (allow-none): store category to search in or %NULL to search in all categories.
  * @query: (allow-none): query string to send or %NULL to get all snaps from the given category.
@@ -883,7 +883,7 @@ snapd_client_find_category_sync (SnapdClient *self,
 
 /**
  * snapd_client_find_refreshable_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -908,7 +908,7 @@ snapd_client_find_refreshable_sync (SnapdClient *self,
 
 /**
  * snapd_client_install_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to install.
  * @channel: (allow-none): channel to install from or %NULL for default.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
@@ -934,7 +934,7 @@ snapd_client_install_sync (SnapdClient *self,
 
 /**
  * snapd_client_install2_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdInstallFlags to control install options.
  * @name: name of snap to install.
  * @channel: (allow-none): channel to install from or %NULL for default.
@@ -969,7 +969,7 @@ snapd_client_install2_sync (SnapdClient *self,
 
 /**
  * snapd_client_install_stream_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdInstallFlags to control install options.
  * @stream: a #GInputStream containing the snap file contents to install.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
@@ -1016,7 +1016,7 @@ snapd_client_install_stream_sync (SnapdClient *self,
 
 /**
  * snapd_client_try_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @path: path to snap directory to try.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
  * @progress_callback_data: (closure): user data to pass to @progress_callback.
@@ -1047,7 +1047,7 @@ snapd_client_try_sync (SnapdClient *self,
 
 /**
  * snapd_client_refresh_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to refresh.
  * @channel: (allow-none): channel to refresh from or %NULL for default.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
@@ -1079,7 +1079,7 @@ snapd_client_refresh_sync (SnapdClient *self,
 
 /**
  * snapd_client_refresh_all_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
  * @progress_callback_data: (closure): user data to pass to @progress_callback.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -1107,7 +1107,7 @@ snapd_client_refresh_all_sync (SnapdClient *self,
 
 /**
  * snapd_client_remove_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to remove.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
  * @progress_callback_data: (closure): user data to pass to @progress_callback.
@@ -1132,7 +1132,7 @@ snapd_client_remove_sync (SnapdClient *self,
 
 /**
  * snapd_client_remove2_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdRemoveFlags to control remove options.
  * @name: name of snap to remove.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
@@ -1165,7 +1165,7 @@ snapd_client_remove2_sync (SnapdClient *self,
 
 /**
  * snapd_client_enable_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to enable.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
  * @progress_callback_data: (closure): user data to pass to @progress_callback.
@@ -1196,7 +1196,7 @@ snapd_client_enable_sync (SnapdClient *self,
 
 /**
  * snapd_client_disable_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to disable.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
  * @progress_callback_data: (closure): user data to pass to @progress_callback.
@@ -1227,7 +1227,7 @@ snapd_client_disable_sync (SnapdClient *self,
 
 /**
  * snapd_client_switch_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to switch channel.
  * @channel: channel to track.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
@@ -1259,7 +1259,7 @@ snapd_client_switch_sync (SnapdClient *self,
 
 /**
  * snapd_client_check_buy_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL
  *     to ignore.
@@ -1285,7 +1285,7 @@ snapd_client_check_buy_sync (SnapdClient *self,
 
 /**
  * snapd_client_buy_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @id: id of snap to buy.
  * @amount: amount of currency to spend, e.g. 0.99.
  * @currency: the currency to buy with as an ISO 4217 currency code, e.g. "NZD".
@@ -1318,7 +1318,7 @@ snapd_client_buy_sync (SnapdClient *self,
 
 /**
  * snapd_client_create_user_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @email: the email of the user to create.
  * @flags: a set of #SnapdCreateUserFlags to control how the user account is created.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -1348,7 +1348,7 @@ snapd_client_create_user_sync (SnapdClient *self,
 
 /**
  * snapd_client_create_users_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL
  *     to ignore.
@@ -1374,7 +1374,7 @@ snapd_client_create_users_sync (SnapdClient *self,
 
 /**
  * snapd_client_get_users_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL
  *     to ignore.
@@ -1400,7 +1400,7 @@ snapd_client_get_users_sync (SnapdClient *self,
 
 /**
  * snapd_client_get_sections_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL
  *     to ignore.
@@ -1431,7 +1431,7 @@ G_GNUC_END_IGNORE_DEPRECATIONS
 
 /**
  * snapd_client_get_categories_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL
  *     to ignore.
@@ -1457,7 +1457,7 @@ snapd_client_get_categories_sync (SnapdClient *self,
 
 /**
  * snapd_client_get_aliases_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL
  *     to ignore.
@@ -1483,7 +1483,7 @@ snapd_client_get_aliases_sync (SnapdClient *self,
 
 /**
  * snapd_client_alias_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @snap: the name of the snap to modify.
  * @app: an app in the snap to make the alias to.
  * @alias: the name of the alias (i.e. the command that will run this app).
@@ -1517,7 +1517,7 @@ snapd_client_alias_sync (SnapdClient *self,
 
 /**
  * snapd_client_unalias_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @snap: (allow-none): the name of the snap to modify or %NULL.
  * @alias: (allow-none): the name of the alias to remove or %NULL to remove all aliases for the given snap.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
@@ -1548,7 +1548,7 @@ snapd_client_unalias_sync (SnapdClient *self,
 
 /**
  * snapd_client_prefer_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @snap: the name of the snap to modify.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
  * @progress_callback_data: (closure): user data to pass to @progress_callback.
@@ -1578,7 +1578,7 @@ snapd_client_prefer_sync (SnapdClient *self,
 
 /**
  * snapd_client_enable_aliases_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @snap: the name of the snap to modify.
  * @aliases: the aliases to modify.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
@@ -1606,7 +1606,7 @@ snapd_client_enable_aliases_sync (SnapdClient *self,
 
 /**
  * snapd_client_disable_aliases_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @snap: the name of the snap to modify.
  * @aliases: the aliases to modify.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
@@ -1634,7 +1634,7 @@ snapd_client_disable_aliases_sync (SnapdClient *self,
 
 /**
  * snapd_client_reset_aliases_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @snap: the name of the snap to modify.
  * @aliases: the aliases to modify.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
@@ -1662,7 +1662,7 @@ snapd_client_reset_aliases_sync (SnapdClient *self,
 
 /**
  * snapd_client_run_snapctl_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @context_id: context for this call.
  * @args: the arguments to pass to snapctl.
  * @stdout_output: (out) (allow-none): the location to write the stdout from the command or %NULL.
@@ -1699,7 +1699,7 @@ G_GNUC_END_IGNORE_DEPRECATIONS
 
 /**
  * snapd_client_run_snapctl2_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @context_id: context for this call.
  * @args: the arguments to pass to snapctl.
  * @stdout_output: (out) (allow-none): the location to write the stdout from the command or %NULL.
@@ -1735,7 +1735,7 @@ snapd_client_run_snapctl2_sync (SnapdClient *self,
 
 /**
  * snapd_client_download_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to download.
  * @channel: (allow-none): channel to download from.
  * @revision: (allow-none): revision to download.
@@ -1766,7 +1766,7 @@ snapd_client_download_sync (SnapdClient *self,
 
 /**
  * snapd_client_check_themes_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @gtk_theme_names: (allow-none): a list of GTK theme names.
  * @icon_theme_names: (allow-none): a list of icon theme names.
  * @sound_theme_names: (allow-none): a list of sound theme names.
@@ -1796,7 +1796,7 @@ snapd_client_check_themes_sync (SnapdClient *self, GStrv gtk_theme_names, GStrv 
 
 /**
  * snapd_client_install_themes_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @gtk_theme_names: (allow-none): a list of GTK theme names.
  * @icon_theme_names: (allow-none): a list of icon theme names.
  * @sound_theme_names: (allow-none): a list of sound theme names.
@@ -1825,7 +1825,7 @@ snapd_client_install_themes_sync (SnapdClient *self, GStrv gtk_theme_names, GStr
 
 /**
  * snapd_client_get_logs_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @names: (allow-none) (array zero-terminated=1): a null-terminated array of service names or %NULL.
  * @n: the number of logs to return or 0 for default.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -1855,7 +1855,7 @@ snapd_client_get_logs_sync (SnapdClient *self,
 
 /**
  * snapd_client_follow_logs_sync:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @names: (allow-none) (array zero-terminated=1): a null-terminated array of service names or %NULL.
  * @log_callback: (scope async): a #SnapdLogCallback to call when a log is received.
  * @log_callback_data: (closure): the data to pass to @log_callback.

--- a/snapd-glib/snapd-client.c
+++ b/snapd-glib/snapd-client.c
@@ -964,7 +964,7 @@ log_cb (SnapdGetLogs *request, SnapdLog *log, gpointer user_data)
 
 /**
  * snapd_client_connect_async:
- * @client: a #SnapdClient
+ * @self: a #SnapdClient
  * @cancellable: (allow-none): a #GCancellable or %NULL
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
  * @user_data: (closure): the data to pass to callback function.
@@ -986,7 +986,7 @@ snapd_client_connect_async (SnapdClient *self,
 
 /**
  * snapd_client_connect_finish:
- * @client: a #SnapdClient
+ * @self: a #SnapdClient
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -1008,7 +1008,7 @@ snapd_client_connect_finish (SnapdClient *self, GAsyncResult *result, GError **e
 
 /**
  * snapd_client_set_socket_path:
- * @client: a #SnapdClient
+ * @self: a #SnapdClient
  * @socket_path: (allow-none): a socket path or %NULL to reset to the default.
  *
  * Set the Unix socket path to connect to snapd with.
@@ -1032,7 +1032,7 @@ snapd_client_set_socket_path (SnapdClient *self, const gchar *socket_path)
 
 /**
  * snapd_client_get_socket_path:
- * @client: a #SnapdClient
+ * @self: a #SnapdClient
  *
  * Get the unix socket path to connect to snapd with.
  *
@@ -1050,7 +1050,7 @@ snapd_client_get_socket_path (SnapdClient *self)
 
 /**
  * snapd_client_set_user_agent:
- * @client: a #SnapdClient
+ * @self: a #SnapdClient
  * @user_agent: (allow-none): a user agent or %NULL.
  *
  * Set the HTTP user-agent that is sent with each request to snapd.
@@ -1071,7 +1071,7 @@ snapd_client_set_user_agent (SnapdClient *self, const gchar *user_agent)
 
 /**
  * snapd_client_get_user_agent:
- * @client: a #SnapdClient
+ * @self: a #SnapdClient
  *
  * Get the HTTP user-agent that is sent with each request to snapd.
  *
@@ -1089,7 +1089,7 @@ snapd_client_get_user_agent (SnapdClient *self)
 
 /**
  * snapd_client_set_allow_interaction:
- * @client: a #SnapdClient
+ * @self: a #SnapdClient
  * @allow_interaction: whether to allow interaction.
  *
  * Set whether snapd operations are allowed to interact with the user.
@@ -1108,7 +1108,7 @@ snapd_client_set_allow_interaction (SnapdClient *self, gboolean allow_interactio
 
 /**
  * snapd_client_get_maintenance:
- * @client: a #SnapdClient
+ * @self: a #SnapdClient
  *
  * Get the maintenance information reported by snapd or %NULL if no maintenance is in progress.
  * This information is updated after every request.
@@ -1127,7 +1127,7 @@ snapd_client_get_maintenance (SnapdClient *self)
 
 /**
  * snapd_client_get_allow_interaction:
- * @client: a #SnapdClient
+ * @self: a #SnapdClient
  *
  * Get whether snapd operations are allowed to interact with the user.
  *
@@ -1145,7 +1145,7 @@ snapd_client_get_allow_interaction (SnapdClient *self)
 
 /**
  * snapd_client_login_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @email: email address to log in with.
  * @password: password to log in with.
  * @otp: (allow-none): response to one-time password challenge.
@@ -1169,7 +1169,7 @@ snapd_client_login_async (SnapdClient *self,
 
 /**
  * snapd_client_login_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -1195,7 +1195,7 @@ snapd_client_login_finish (SnapdClient *self, GAsyncResult *result, GError **err
 
 /**
  * snapd_client_login2_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @email: email address to log in with.
  * @password: password to log in with.
  * @otp: (allow-none): response to one-time password challenge.
@@ -1221,7 +1221,7 @@ snapd_client_login2_async (SnapdClient *self,
 
 /**
  * snapd_client_login2_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -1247,7 +1247,7 @@ snapd_client_login2_finish (SnapdClient *self, GAsyncResult *result, GError **er
 
 /**
  * snapd_client_logout_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @id: login ID to use.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
@@ -1271,7 +1271,7 @@ snapd_client_logout_async (SnapdClient *self,
 
 /**
  * snapd_client_logout_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -1297,7 +1297,7 @@ snapd_client_logout_finish (SnapdClient *self, GAsyncResult *result, GError **er
 
 /**
  * snapd_client_set_auth_data:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @auth_data: (allow-none): a #SnapdAuthData or %NULL.
  *
  * Set the authorization data to use for requests. Authorization data can be
@@ -1321,7 +1321,7 @@ snapd_client_set_auth_data (SnapdClient *self, SnapdAuthData *auth_data)
 
 /**
  * snapd_client_get_auth_data:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  *
  * Get the authorization data that is used for requests.
  *
@@ -1339,7 +1339,7 @@ snapd_client_get_auth_data (SnapdClient *self)
 
 /**
  * snapd_client_get_changes_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @filter: changes to filter on.
  * @snap_name: (allow-none): name of snap to filter on or %NULL for changes for any snap.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -1378,7 +1378,7 @@ snapd_client_get_changes_async (SnapdClient *self,
 
 /**
  * snapd_client_get_changes_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -1404,7 +1404,7 @@ snapd_client_get_changes_finish (SnapdClient *self, GAsyncResult *result, GError
 
 /**
  * snapd_client_get_change_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @id: a change ID to get information on.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
@@ -1429,7 +1429,7 @@ snapd_client_get_change_async (SnapdClient *self,
 
 /**
  * snapd_client_get_change_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -1455,7 +1455,7 @@ snapd_client_get_change_finish (SnapdClient *self, GAsyncResult *result, GError 
 
 /**
  * snapd_client_abort_change_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @id: a change ID to abort.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
@@ -1480,7 +1480,7 @@ snapd_client_abort_change_async (SnapdClient *self,
 
 /**
  * snapd_client_abort_change_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -1506,7 +1506,7 @@ snapd_client_abort_change_finish (SnapdClient *self, GAsyncResult *result, GErro
 
 /**
  * snapd_client_get_system_information_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
  * @user_data: (closure): the data to pass to callback function.
@@ -1528,7 +1528,7 @@ snapd_client_get_system_information_async (SnapdClient *self,
 
 /**
  * snapd_client_get_system_information_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -1554,7 +1554,7 @@ snapd_client_get_system_information_finish (SnapdClient *self, GAsyncResult *res
 
 /**
  * snapd_client_list_one_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to get.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
@@ -1576,7 +1576,7 @@ snapd_client_list_one_async (SnapdClient *self,
 
 /**
  * snapd_client_list_one_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -1596,7 +1596,7 @@ snapd_client_list_one_finish (SnapdClient *self, GAsyncResult *result, GError **
 
 /**
  * snapd_client_get_snap_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to get.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
@@ -1620,7 +1620,7 @@ snapd_client_get_snap_async (SnapdClient *self,
 
 /**
  * snapd_client_get_snap_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -1646,7 +1646,7 @@ snapd_client_get_snap_finish (SnapdClient *self, GAsyncResult *result, GError **
 
 /**
  * snapd_client_get_snap_conf_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to get configuration from.
  * @keys: (allow-none): keys to returns or %NULL to return all.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -1673,7 +1673,7 @@ snapd_client_get_snap_conf_async (SnapdClient *self,
 
 /**
  * snapd_client_get_snap_conf_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -1699,7 +1699,7 @@ snapd_client_get_snap_conf_finish (SnapdClient *self, GAsyncResult *result, GErr
 
 /**
  * snapd_client_set_snap_conf_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to set configuration for.
  * @key_values: (element-type utf8 GVariant): Keys to set.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -1727,7 +1727,7 @@ snapd_client_set_snap_conf_async (SnapdClient *self,
 
 /**
  * snapd_client_set_snap_conf_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -1749,7 +1749,7 @@ snapd_client_set_snap_conf_finish (SnapdClient *self, GAsyncResult *result, GErr
 
 /**
  * snapd_client_get_apps_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdGetAppsFlags to control what results are returned.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
@@ -1771,7 +1771,7 @@ snapd_client_get_apps_async (SnapdClient *self,
 
 /**
  * snapd_client_get_apps_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -1791,7 +1791,7 @@ snapd_client_get_apps_finish (SnapdClient *self, GAsyncResult *result, GError **
 
 /**
  * snapd_client_get_apps2_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdGetAppsFlags to control what results are returned.
  * @snaps: (allow-none): A list of snap names to return results for. If %NULL or empty then apps for all installed snaps are returned.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -1819,7 +1819,7 @@ snapd_client_get_apps2_async (SnapdClient *self,
 
 /**
  * snapd_client_get_apps2_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -1845,7 +1845,7 @@ snapd_client_get_apps2_finish (SnapdClient *self, GAsyncResult *result, GError *
 
 /**
  * snapd_client_get_icon_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to get icon for.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
@@ -1869,7 +1869,7 @@ snapd_client_get_icon_async (SnapdClient *self,
 
 /**
  * snapd_client_get_icon_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -1895,7 +1895,7 @@ snapd_client_get_icon_finish (SnapdClient *self, GAsyncResult *result, GError **
 
 /**
  * snapd_client_list_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
  * @user_data: (closure): the data to pass to callback function.
@@ -1915,7 +1915,7 @@ snapd_client_list_async (SnapdClient *self,
 
 /**
  * snapd_client_list_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -1935,7 +1935,7 @@ snapd_client_list_finish (SnapdClient *self, GAsyncResult *result, GError **erro
 
 /**
  * snapd_client_get_snaps_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdGetSnapsFlags to control what results are returned.
  * @names: (allow-none): A list of snap names to return results for. If %NULL or empty then all installed snaps are returned.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -1963,7 +1963,7 @@ snapd_client_get_snaps_async (SnapdClient *self,
 
 /**
  * snapd_client_get_snaps_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -1989,7 +1989,7 @@ snapd_client_get_snaps_finish (SnapdClient *self, GAsyncResult *result, GError *
 
 /**
  * snapd_client_get_assertions_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @type: assertion type to get.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
@@ -2014,7 +2014,7 @@ snapd_client_get_assertions_async (SnapdClient *self,
 
 /**
  * snapd_client_get_assertions_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -2040,7 +2040,7 @@ snapd_client_get_assertions_finish (SnapdClient *self, GAsyncResult *result, GEr
 
 /**
  * snapd_client_add_assertions_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @assertions: assertions to add.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
@@ -2065,7 +2065,7 @@ snapd_client_add_assertions_async (SnapdClient *self,
 
 /**
  * snapd_client_add_assertions_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -2087,7 +2087,7 @@ snapd_client_add_assertions_finish (SnapdClient *self, GAsyncResult *result, GEr
 
 /**
  * snapd_client_get_interfaces_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
  * @user_data: (closure): the data to pass to callback function.
@@ -2110,7 +2110,7 @@ snapd_client_get_interfaces_async (SnapdClient *self,
 
 /**
  * snapd_client_get_interfaces_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @plugs: (out) (allow-none) (transfer container) (element-type SnapdPlug): the location to store the array of #SnapdPlug or %NULL.
  * @slots: (out) (allow-none) (transfer container) (element-type SnapdSlot): the location to store the array of #SnapdSlot or %NULL.
@@ -2145,7 +2145,7 @@ snapd_client_get_interfaces_finish (SnapdClient *self, GAsyncResult *result,
 
 /**
  * snapd_client_get_interfaces2_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdGetInterfacesFlags to control what information is returned about the interfaces.
  * @names: (allow-none) (array zero-terminated=1): a null-terminated array of interface names or %NULL.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -2181,7 +2181,7 @@ snapd_client_get_interfaces2_async (SnapdClient *self,
 
 /**
  * snapd_client_get_interfaces2_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -2209,7 +2209,7 @@ snapd_client_get_interfaces2_finish (SnapdClient *self,
 
 /**
  * snapd_client_get_connections_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
  * @user_data: (closure): the data to pass to callback function.
@@ -2229,7 +2229,7 @@ snapd_client_get_connections_async (SnapdClient *self,
 
 /**
  * snapd_client_get_connections_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @established: (out) (allow-none) (transfer container) (element-type SnapdConnection): the location to store the array of connections or %NULL.
  * @undesired: (out) (allow-none) (transfer container) (element-type SnapdConnection): the location to store the array of auto-connected connections that have been manually disconnected or %NULL.
@@ -2256,7 +2256,7 @@ snapd_client_get_connections_finish (SnapdClient *self, GAsyncResult *result,
 
 /**
  * snapd_client_get_connections2_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdGetConnectionsFlags to control what results are returned.
  * @snap: (allow-none): the name of the snap to get connections for or %NULL for all snaps.
  * @interface: (allow-none): the name of the interface to get connections for or %NULL for all interfaces.
@@ -2285,7 +2285,7 @@ snapd_client_get_connections2_async (SnapdClient *self,
 
 /**
  * snapd_client_get_connections2_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @established: (out) (allow-none) (transfer container) (element-type SnapdConnection): the location to store the array of connections or %NULL.
  * @undesired: (out) (allow-none) (transfer container) (element-type SnapdConnection): the location to store the array of auto-connected connections that have been manually disconnected or %NULL.
@@ -2326,7 +2326,7 @@ snapd_client_get_connections2_finish (SnapdClient *self, GAsyncResult *result,
 
 /**
  * snapd_client_connect_interface_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @plug_snap: name of snap containing plug.
  * @plug_name: name of plug to connect.
  * @slot_snap: name of snap containing socket.
@@ -2357,7 +2357,7 @@ snapd_client_connect_interface_async (SnapdClient *self,
 
 /**
  * snapd_client_connect_interface_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -2380,7 +2380,7 @@ snapd_client_connect_interface_finish (SnapdClient *self,
 
 /**
  * snapd_client_disconnect_interface_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @plug_snap: name of snap containing plug.
  * @plug_name: name of plug to disconnect.
  * @slot_snap: name of snap containing socket.
@@ -2411,7 +2411,7 @@ snapd_client_disconnect_interface_async (SnapdClient *self,
 
 /**
  * snapd_client_disconnect_interface_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -2434,7 +2434,7 @@ snapd_client_disconnect_interface_finish (SnapdClient *self,
 
 /**
  * snapd_client_find_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdFindFlags to control how the find is performed.
  * @query: (allow-none): query string to send or %NULL to return featured snaps.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -2457,7 +2457,7 @@ snapd_client_find_async (SnapdClient *self,
 
 /**
  * snapd_client_find_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @suggested_currency: (out) (allow-none): location to store the ISO 4217 currency that is suggested to purchase with.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
@@ -2477,7 +2477,7 @@ snapd_client_find_finish (SnapdClient *self, GAsyncResult *result, gchar **sugge
 
 /**
  * snapd_client_find_section_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdFindFlags to control how the find is performed.
  * @section: (allow-none): store section to search in or %NULL to search in all sections.
  * @query: (allow-none): query string to send or %NULL to get all snaps from the given section.
@@ -2517,7 +2517,7 @@ snapd_client_find_section_async (SnapdClient *self,
 
 /**
  * snapd_client_find_section_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @suggested_currency: (out) (allow-none): location to store the ISO 4217 currency that is suggested to purchase with.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
@@ -2548,7 +2548,7 @@ snapd_client_find_section_finish (SnapdClient *self, GAsyncResult *result, gchar
 
 /**
  * snapd_client_find_category_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdFindFlags to control how the find is performed.
  * @category: (allow-none): store category to search in or %NULL to search in all categories.
  * @query: (allow-none): query string to send or %NULL to get all snaps from the given category.
@@ -2587,7 +2587,7 @@ snapd_client_find_category_async (SnapdClient *self,
 
 /**
  * snapd_client_find_category_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @suggested_currency: (out) (allow-none): location to store the ISO 4217 currency that is suggested to purchase with.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
@@ -2617,7 +2617,7 @@ snapd_client_find_category_finish (SnapdClient *self, GAsyncResult *result, gcha
 
 /**
  * snapd_client_find_refreshable_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
  * @user_data: (closure): the data to pass to callback function.
@@ -2640,7 +2640,7 @@ snapd_client_find_refreshable_async (SnapdClient *self,
 
 /**
  * snapd_client_find_refreshable_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -2667,7 +2667,7 @@ snapd_client_find_refreshable_finish (SnapdClient *self, GAsyncResult *result, G
 
 /**
  * snapd_client_install_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to install.
  * @channel: (allow-none): channel to install from or %NULL for default.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
@@ -2693,7 +2693,7 @@ snapd_client_install_async (SnapdClient *self,
 
 /**
  * snapd_client_install_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -2713,7 +2713,7 @@ snapd_client_install_finish (SnapdClient *self, GAsyncResult *result, GError **e
 
 /**
  * snapd_client_install2_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdInstallFlags to control install options.
  * @name: name of snap to install.
  * @channel: (allow-none): channel to install from or %NULL for default.
@@ -2755,7 +2755,7 @@ snapd_client_install2_async (SnapdClient *self,
 
 /**
  * snapd_client_install2_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -2829,7 +2829,7 @@ stream_read_cb (GObject *source_object, GAsyncResult *result, gpointer user_data
 
 /**
  * snapd_client_install_stream_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdInstallFlags to control install options.
  * @stream: a #GInputStream containing the snap file contents to install.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
@@ -2867,7 +2867,7 @@ snapd_client_install_stream_async (SnapdClient *self,
 
 /**
  * snapd_client_install_stream_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -2889,7 +2889,7 @@ snapd_client_install_stream_finish (SnapdClient *self, GAsyncResult *result, GEr
 
 /**
  * snapd_client_try_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @path: path to snap directory to try.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
  * @progress_callback_data: (closure): user data to pass to @progress_callback.
@@ -2917,7 +2917,7 @@ snapd_client_try_async (SnapdClient *self,
 
 /**
  * snapd_client_try_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -2939,7 +2939,7 @@ snapd_client_try_finish (SnapdClient *self, GAsyncResult *result, GError **error
 
 /**
  * snapd_client_refresh_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to refresh.
  * @channel: (allow-none): channel to refresh from or %NULL for default.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
@@ -2969,7 +2969,7 @@ snapd_client_refresh_async (SnapdClient *self,
 
 /**
  * snapd_client_refresh_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -2991,7 +2991,7 @@ snapd_client_refresh_finish (SnapdClient *self, GAsyncResult *result, GError **e
 
 /**
  * snapd_client_refresh_all_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
  * @progress_callback_data: (closure): user data to pass to @progress_callback.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -3016,7 +3016,7 @@ snapd_client_refresh_all_async (SnapdClient *self,
 
 /**
  * snapd_client_refresh_all_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -3043,7 +3043,7 @@ snapd_client_refresh_all_finish (SnapdClient *self, GAsyncResult *result, GError
 
 /**
  * snapd_client_remove_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to remove.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
  * @progress_callback_data: (closure): user data to pass to @progress_callback.
@@ -3068,7 +3068,7 @@ snapd_client_remove_async (SnapdClient *self,
 
 /**
  * snapd_client_remove_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -3088,7 +3088,7 @@ snapd_client_remove_finish (SnapdClient *self, GAsyncResult *result, GError **er
 
 /**
  * snapd_client_remove2_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @flags: a set of #SnapdRemoveFlags to control remove options.
  * @name: name of snap to remove.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
@@ -3120,7 +3120,7 @@ snapd_client_remove2_async (SnapdClient *self,
 
 /**
  * snapd_client_remove2_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -3142,7 +3142,7 @@ snapd_client_remove2_finish (SnapdClient *self, GAsyncResult *result, GError **e
 
 /**
  * snapd_client_enable_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to enable.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
  * @progress_callback_data: (closure): user data to pass to @progress_callback.
@@ -3170,7 +3170,7 @@ snapd_client_enable_async (SnapdClient *self,
 
 /**
  * snapd_client_enable_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -3192,7 +3192,7 @@ snapd_client_enable_finish (SnapdClient *self, GAsyncResult *result, GError **er
 
 /**
  * snapd_client_disable_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to disable.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
  * @progress_callback_data: (closure): user data to pass to @progress_callback.
@@ -3220,7 +3220,7 @@ snapd_client_disable_async (SnapdClient *self,
 
 /**
  * snapd_client_disable_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -3242,7 +3242,7 @@ snapd_client_disable_finish (SnapdClient *self, GAsyncResult *result, GError **e
 
 /**
  * snapd_client_switch_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to switch channel.
  * @channel: channel to track.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
@@ -3272,7 +3272,7 @@ snapd_client_switch_async (SnapdClient *self,
 
 /**
  * snapd_client_switch_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -3294,7 +3294,7 @@ snapd_client_switch_finish (SnapdClient *self, GAsyncResult *result, GError **er
 
 /**
  * snapd_client_check_buy_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
  * @user_data: (closure): the data to pass to callback function.
@@ -3316,7 +3316,7 @@ snapd_client_check_buy_async (SnapdClient *self,
 
 /**
  * snapd_client_check_buy_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -3338,7 +3338,7 @@ snapd_client_check_buy_finish (SnapdClient *self, GAsyncResult *result, GError *
 
 /**
  * snapd_client_buy_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @id: id of snap to buy.
  * @amount: amount of currency to spend, e.g. 0.99.
  * @currency: the currency to buy with as an ISO 4217 currency code, e.g. "NZD".
@@ -3366,7 +3366,7 @@ snapd_client_buy_async (SnapdClient *self,
 
 /**
  * snapd_client_buy_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -3388,7 +3388,7 @@ snapd_client_buy_finish (SnapdClient *self, GAsyncResult *result, GError **error
 
 /**
  * snapd_client_create_user_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @email: the email of the user to create.
  * @flags: a set of #SnapdCreateUserFlags to control how the user account is created.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -3418,7 +3418,7 @@ snapd_client_create_user_async (SnapdClient *self,
 
 /**
  * snapd_client_create_user_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -3444,7 +3444,7 @@ snapd_client_create_user_finish (SnapdClient *self, GAsyncResult *result, GError
 
 /**
  * snapd_client_create_users_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
  * @user_data: (closure): the data to pass to callback function.
@@ -3466,7 +3466,7 @@ snapd_client_create_users_async (SnapdClient *self,
 
 /**
  * snapd_client_create_users_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -3492,7 +3492,7 @@ snapd_client_create_users_finish (SnapdClient *self, GAsyncResult *result, GErro
 
 /**
  * snapd_client_get_users_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
  * @user_data: (closure): the data to pass to callback function.
@@ -3514,7 +3514,7 @@ snapd_client_get_users_async (SnapdClient *self,
 
 /**
  * snapd_client_get_users_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -3540,7 +3540,7 @@ snapd_client_get_users_finish (SnapdClient *self, GAsyncResult *result, GError *
 
 /**
  * snapd_client_get_sections_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
  * @user_data: (closure): the data to pass to callback function.
@@ -3563,7 +3563,7 @@ snapd_client_get_sections_async (SnapdClient *self,
 
 /**
  * snapd_client_get_sections_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -3590,7 +3590,7 @@ snapd_client_get_sections_finish (SnapdClient *self, GAsyncResult *result, GErro
 
 /**
  * snapd_client_get_categories_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
  * @user_data: (closure): the data to pass to callback function.
@@ -3612,7 +3612,7 @@ snapd_client_get_categories_async (SnapdClient *self,
 
 /**
  * snapd_client_get_categories_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -3638,7 +3638,7 @@ snapd_client_get_categories_finish (SnapdClient *self, GAsyncResult *result, GEr
 
 /**
  * snapd_client_get_aliases_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
  * @callback: (scope async): a #GAsyncReadyCallback to call when the request is satisfied.
  * @user_data: (closure): the data to pass to callback function.
@@ -3660,7 +3660,7 @@ snapd_client_get_aliases_async (SnapdClient *self,
 
 /**
  * snapd_client_get_aliases_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -3697,7 +3697,7 @@ send_change_aliases_request (SnapdClient *self,
 
 /**
  * snapd_client_alias_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @snap: the name of the snap to modify.
  * @app: an app in the snap to make the alias to.
  * @alias: the name of the alias (i.e. the command that will run this app).
@@ -3727,7 +3727,7 @@ snapd_client_alias_async (SnapdClient *self,
 
 /**
  * snapd_client_alias_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -3749,7 +3749,7 @@ snapd_client_alias_finish (SnapdClient *self, GAsyncResult *result, GError **err
 
 /**
  * snapd_client_unalias_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @snap: (allow-none): the name of the snap to modify or %NULL.
  * @alias: (allow-none): the name of the alias to remove or %NULL to remove all aliases for the given snap.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
@@ -3776,7 +3776,7 @@ snapd_client_unalias_async (SnapdClient *self,
 
 /**
  * snapd_client_unalias_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -3798,7 +3798,7 @@ snapd_client_unalias_finish (SnapdClient *self, GAsyncResult *result, GError **e
 
 /**
  * snapd_client_prefer_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @snap: the name of the snap to modify.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
  * @progress_callback_data: (closure): user data to pass to @progress_callback.
@@ -3824,7 +3824,7 @@ snapd_client_prefer_async (SnapdClient *self,
 
 /**
  * snapd_client_prefer_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -3846,7 +3846,7 @@ snapd_client_prefer_finish (SnapdClient *self, GAsyncResult *result, GError **er
 
 /**
  * snapd_client_enable_aliases_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @snap: the name of the snap to modify.
  * @aliases: the aliases to modify.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
@@ -3875,7 +3875,7 @@ snapd_client_enable_aliases_async (SnapdClient *self,
 
 /**
  * snapd_client_enable_aliases_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -3898,7 +3898,7 @@ snapd_client_enable_aliases_finish (SnapdClient *self, GAsyncResult *result, GEr
 
 /**
  * snapd_client_disable_aliases_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @snap: the name of the snap to modify.
  * @aliases: the aliases to modify.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
@@ -3927,7 +3927,7 @@ snapd_client_disable_aliases_async (SnapdClient *self,
 
 /**
  * snapd_client_disable_aliases_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -3950,7 +3950,7 @@ snapd_client_disable_aliases_finish (SnapdClient *self, GAsyncResult *result, GE
 
 /**
  * snapd_client_reset_aliases_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @snap: the name of the snap to modify.
  * @aliases: the aliases to modify.
  * @progress_callback: (allow-none) (scope call): function to callback with progress.
@@ -3979,7 +3979,7 @@ snapd_client_reset_aliases_async (SnapdClient *self,
 
 /**
  * snapd_client_reset_aliases_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -4002,7 +4002,7 @@ snapd_client_reset_aliases_finish (SnapdClient *self, GAsyncResult *result, GErr
 
 /**
  * snapd_client_run_snapctl_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @context_id: context for this call.
  * @args: the arguments to pass to snapctl.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -4025,7 +4025,7 @@ snapd_client_run_snapctl_async (SnapdClient *self,
 
 /**
  * snapd_client_run_snapctl_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @stdout_output: (out) (allow-none): the location to write the stdout from the command or %NULL.
  * @stderr_output: (out) (allow-none): the location to write the stderr from the command or %NULL.
@@ -4057,7 +4057,7 @@ snapd_client_run_snapctl_finish (SnapdClient *self, GAsyncResult *result,
 
 /**
  * snapd_client_run_snapctl2_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @context_id: context for this call.
  * @args: the arguments to pass to snapctl.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -4084,7 +4084,7 @@ snapd_client_run_snapctl2_async (SnapdClient *self,
 
 /**
  * snapd_client_run_snapctl2_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @stdout_output: (out) (allow-none): the location to write the stdout from the command or %NULL.
  * @stderr_output: (out) (allow-none): the location to write the stderr from the command or %NULL.
@@ -4130,7 +4130,7 @@ snapd_client_run_snapctl2_finish (SnapdClient *self, GAsyncResult *result,
 
 /**
  * snapd_client_download_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @name: name of snap to download.
  * @channel: (allow-none): channel to download from.
  * @revision: (allow-none): revision to download.
@@ -4157,7 +4157,7 @@ snapd_client_download_async (SnapdClient *self,
 
 /**
  * snapd_client_download_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -4184,7 +4184,7 @@ snapd_client_download_finish (SnapdClient *self, GAsyncResult *result, GError **
 
 /**
  * snapd_client_check_themes_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @gtk_theme_names: (allow-none): a list of GTK theme names.
  * @icon_theme_names: (allow-none): a list of icon theme names.
  * @sound_theme_names: (allow-none): a list of sound theme names.
@@ -4214,7 +4214,7 @@ snapd_client_check_themes_async (SnapdClient *self,
 
 /**
  * snapd_client_check_themes_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @gtk_theme_status: (out) (transfer container) (element-type utf8 SnapdThemeStatus): status of GTK themes.
  * @icon_theme_status: (out) (transfer container) (element-type utf8 SnapdThemeStatus): status of icon themes.
@@ -4251,7 +4251,7 @@ snapd_client_check_themes_finish (SnapdClient *self, GAsyncResult *result, GHash
 
 /**
  * snapd_client_install_themes_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @gtk_theme_names: (allow-none): a list of GTK theme names.
  * @icon_theme_names: (allow-none): a list of icon theme names.
  * @sound_theme_names: (allow-none): a list of sound theme names.
@@ -4277,7 +4277,7 @@ snapd_client_install_themes_async (SnapdClient *self, GStrv gtk_theme_names, GSt
 
 /**
  * snapd_client_install_themes_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -4299,7 +4299,7 @@ snapd_client_install_themes_finish (SnapdClient *self, GAsyncResult *result, GEr
 
 /**
  * snapd_client_get_logs_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @names: (allow-none) (array zero-terminated=1): a null-terminated array of service names or %NULL.
  * @n: the number of logs to return or 0 for default.
  * @cancellable: (allow-none): a #GCancellable or %NULL.
@@ -4327,7 +4327,7 @@ snapd_client_get_logs_async (SnapdClient *self,
 
 /**
  * snapd_client_get_logs_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *
@@ -4353,7 +4353,7 @@ snapd_client_get_logs_finish (SnapdClient *self, GAsyncResult *result, GError **
 
 /**
  * snapd_client_follow_logs_async:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @names: (allow-none) (array zero-terminated=1): a null-terminated array of service names or %NULL.
  * @log_callback: (scope async): a #SnapdLogCallback to call when a log is received.
  * @log_callback_data: (closure): the data to pass to @log_callback.
@@ -4381,7 +4381,7 @@ snapd_client_follow_logs_async (SnapdClient *self, GStrv names,
 
 /**
  * snapd_client_follow_logs_finish:
- * @client: a #SnapdClient.
+ * @self: a #SnapdClient.
  * @result: a #GAsyncResult.
  * @error: (allow-none): #GError location to store the error occurring, or %NULL to ignore.
  *

--- a/snapd-glib/snapd-connection.c
+++ b/snapd-glib/snapd-connection.c
@@ -63,7 +63,7 @@ G_DEFINE_TYPE (SnapdConnection, snapd_connection, G_TYPE_OBJECT)
 
 /**
  * snapd_connection_get_slot:
- * @connection: a #SnapdConnection.
+ * @self: a #SnapdConnection.
  *
  * Get the slot this connection is made with.
  *
@@ -80,7 +80,7 @@ snapd_connection_get_slot (SnapdConnection *self)
 
 /**
  * snapd_connection_get_plug:
- * @connection: a #SnapdConnection.
+ * @self: a #SnapdConnection.
  *
  * Get the plug this connection is made with.
  *
@@ -97,7 +97,7 @@ snapd_connection_get_plug (SnapdConnection *self)
 
 /**
  * snapd_connection_get_interface:
- * @connection: a #SnapdConnection.
+ * @self: a #SnapdConnection.
  *
  * Get the interface this connections uses.
  *
@@ -114,7 +114,7 @@ snapd_connection_get_interface (SnapdConnection *self)
 
 /**
  * snapd_connection_get_manual:
- * @connection: a #SnapdConnection.
+ * @self: a #SnapdConnection.
  *
  * Get if this connection was made manually.
  *
@@ -131,7 +131,7 @@ snapd_connection_get_manual (SnapdConnection *self)
 
 /**
  * snapd_connection_get_gadget:
- * @connection: a #SnapdConnection.
+ * @self: a #SnapdConnection.
  *
  * Get if this connection was made by the gadget snap.
  *
@@ -148,7 +148,7 @@ snapd_connection_get_gadget (SnapdConnection *self)
 
 /**
  * snapd_connection_get_slot_attribute_names:
- * @connection: a #SnapdConnection.
+ * @self: a #SnapdConnection.
  * @length: (out) (allow-none): location to write number of attributes or %NULL if not required.
  *
  * Get the names of the attributes the connected slot has.
@@ -179,7 +179,7 @@ snapd_connection_get_slot_attribute_names (SnapdConnection *self, guint *length)
 
 /**
  * snapd_connection_has_slot_attribute:
- * @connection: a #SnapdConnection.
+ * @self: a #SnapdConnection.
  * @name: an attribute name.
  *
  * Check if the connected slot has an attribute.
@@ -197,7 +197,7 @@ snapd_connection_has_slot_attribute (SnapdConnection *self, const gchar *name)
 
 /**
  * snapd_connection_get_slot_attribute:
- * @connection: a #SnapdConnection.
+ * @self: a #SnapdConnection.
  * @name: an attribute name.
  *
  * Get an attribute for connected slot.
@@ -215,7 +215,7 @@ snapd_connection_get_slot_attribute (SnapdConnection *self, const gchar *name)
 
 /**
  * snapd_connection_get_plug_attribute_names:
- * @connection: a #SnapdConnection.
+ * @self: a #SnapdConnection.
  * @length: (out) (allow-none): location to write number of attributes or %NULL if not required.
  *
  * Get the names of the attributes the connected plug has.
@@ -246,7 +246,7 @@ snapd_connection_get_plug_attribute_names (SnapdConnection *self, guint *length)
 
 /**
  * snapd_connection_has_plug_attribute:
- * @connection: a #SnapdConnection.
+ * @self: a #SnapdConnection.
  * @name: an attribute name.
  *
  * Check if the connected plug has an attribute.
@@ -264,7 +264,7 @@ snapd_connection_has_plug_attribute (SnapdConnection *self, const gchar *name)
 
 /**
  * snapd_connection_get_plug_attribute:
- * @connection: a #SnapdConnection.
+ * @self: a #SnapdConnection.
  * @name: an attribute name.
  *
  * Get an attribute for connected plug.
@@ -282,7 +282,7 @@ snapd_connection_get_plug_attribute (SnapdConnection *self, const gchar *name)
 
 /**
  * snapd_connection_get_name:
- * @connection: a #SnapdConnection.
+ * @self: a #SnapdConnection.
  *
  * Get the name of this connection (i.e. a slot or plug name).
  *
@@ -300,7 +300,7 @@ snapd_connection_get_name (SnapdConnection *self)
 
 /**
  * snapd_connection_get_snap:
- * @connection: a #SnapdConnection.
+ * @self: a #SnapdConnection.
  *
  * Get the snap this connection is on.
  *

--- a/snapd-glib/snapd-icon.c
+++ b/snapd-glib/snapd-icon.c
@@ -47,7 +47,7 @@ G_DEFINE_TYPE (SnapdIcon, snapd_icon, G_TYPE_OBJECT)
 
 /**
  * snapd_icon_get_mime_type:
- * @icon: a #SnapdIcon.
+ * @self: a #SnapdIcon.
  *
  * Get the mime-type for this icon, e.g. "image/png".
  *
@@ -64,7 +64,7 @@ snapd_icon_get_mime_type (SnapdIcon *self)
 
 /**
  * snapd_icon_get_data:
- * @icon: a #SnapdIcon.
+ * @self: a #SnapdIcon.
  *
  * Get the binary data for this icon.
  *

--- a/snapd-glib/snapd-interface.c
+++ b/snapd-glib/snapd-interface.c
@@ -56,7 +56,7 @@ G_DEFINE_TYPE (SnapdInterface, snapd_interface, G_TYPE_OBJECT);
 
 /**
  * snapd_interface_get_name:
- * @interface: a #SnapdInterface
+ * @self: a #SnapdInterface
  *
  * Get the name of this interface.
  *
@@ -73,7 +73,7 @@ snapd_interface_get_name (SnapdInterface *self)
 
 /**
  * snapd_interface_get_summary:
- * @interface: a #SnapdInterface
+ * @self: a #SnapdInterface
  *
  * Get the summary of this interface.
  *
@@ -90,7 +90,7 @@ snapd_interface_get_summary (SnapdInterface *self)
 
 /**
  * snapd_interface_get_doc_url:
- * @interface: a #SnapdInterface
+ * @self: a #SnapdInterface
  *
  * Get the documentation URL of this interface.
  *
@@ -107,7 +107,7 @@ snapd_interface_get_doc_url (SnapdInterface *self)
 
 /**
  * snapd_interface_get_plugs:
- * @interface: a #SnapdInterface
+ * @self: a #SnapdInterface
  *
  * Get the plugs matching this interface type.
  *
@@ -124,7 +124,7 @@ snapd_interface_get_plugs (SnapdInterface *self)
 
 /**
  * snapd_interface_get_slots:
- * @interface: a #SnapdInterface
+ * @self: a #SnapdInterface
  *
  * Get the slots matching this interface type.
  *
@@ -141,7 +141,7 @@ snapd_interface_get_slots (SnapdInterface *self)
 
 /**
  * snapd_interface_make_label:
- * @interface: a #SnapdInterface
+ * @self: a #SnapdInterface
  *
  * Make a label for this interface suitable for a user interface.
  *

--- a/snapd-glib/snapd-log.c
+++ b/snapd-glib/snapd-log.c
@@ -50,7 +50,7 @@ G_DEFINE_TYPE (SnapdLog, snapd_log, G_TYPE_OBJECT)
 
 /**
  * snapd_log_get_timestamp:
- * @log: a #SnapdLog.
+ * @self: a #SnapdLog.
  *
  * Get the time this log was generated.
  *
@@ -67,7 +67,7 @@ snapd_log_get_timestamp (SnapdLog *self)
 
 /**
  * snapd_log_get_message:
- * @log: a #SnapdLog.
+ * @self: a #SnapdLog.
  *
  * Get the message of this log, e.g. "service started"
  *
@@ -84,7 +84,7 @@ snapd_log_get_message (SnapdLog *self)
 
 /**
  * snapd_log_get_sid:
- * @log: a #SnapdLog.
+ * @self: a #SnapdLog.
  *
  * Get the syslog id of this log, e.g. "cups.cups-browsed"
  *
@@ -101,7 +101,7 @@ snapd_log_get_sid (SnapdLog *self)
 
 /**
  * snapd_log_get_pid:
- * @log: a #SnapdLog.
+ * @self: a #SnapdLog.
  *
  * Get the process ID of this log, e.g. "1234"
  *

--- a/snapd-glib/snapd-maintenance.c
+++ b/snapd-glib/snapd-maintenance.c
@@ -48,7 +48,7 @@ G_DEFINE_TYPE (SnapdMaintenance, snapd_maintenance, G_TYPE_OBJECT)
 
 /**
  * snapd_maintenance_get_kind:
- * @maintenance: a #SnapdMaintenance.
+ * @self: a #SnapdMaintenance.
  *
  * Get the kind of maintenance kind, e.g. %SNAPD_MAINTENANCE_KIND_DAEMON_RESTART.
  *
@@ -65,7 +65,7 @@ snapd_maintenance_get_kind (SnapdMaintenance *self)
 
 /**
  * snapd_maintenance_get_message:
- * @maintenance: a #SnapdMaintenance.
+ * @self: a #SnapdMaintenance.
  *
  * Get the user readable message associate with the maintenance state.
  *

--- a/snapd-glib/snapd-markdown-node.c
+++ b/snapd-glib/snapd-markdown-node.c
@@ -142,7 +142,7 @@ snapd_markdown_node_init (SnapdMarkdownNode *self)
 
 /**
  * snapd_markdown_node_get_node_type:
- * @node: a #SnapdMarkdownNode.
+ * @self: a #SnapdMarkdownNode.
  *
  * Get the type of node this is.
  *
@@ -159,7 +159,7 @@ snapd_markdown_node_get_node_type (SnapdMarkdownNode *self)
 
 /**
  * snapd_markdown_node_get_text:
- * @node: a #SnapdMarkdownNode.
+ * @self: a #SnapdMarkdownNode.
  *
  * Gets the text associated with this node. This is only present for nodes of type
  * %SNAPD_MARKDOWN_NODE_TYPE_TEXT.
@@ -177,7 +177,7 @@ snapd_markdown_node_get_text (SnapdMarkdownNode *self)
 
 /**
  * snapd_markdown_node_get_children:
- * @node: a #SnapdMarkdownNode.
+ * @self: a #SnapdMarkdownNode.
  *
  * Get the child nodes of this node.
  *

--- a/snapd-glib/snapd-markdown-parser.c
+++ b/snapd-glib/snapd-markdown-parser.c
@@ -835,7 +835,7 @@ snapd_markdown_parser_new (SnapdMarkdownVersion version)
 
 /**
  * snapd_markdown_parser_set_preserve_whitespace:
- * @parser: a #SnapdMarkdownParser.
+ * @self: a #SnapdMarkdownParser.
  * @preserve_whitespace: %TRUE if the parse should keep paragraph whitespace intact.
  *
  * Consecutive paragraph whitespace (space, tabs, newlines) is automatically
@@ -854,7 +854,7 @@ snapd_markdown_parser_set_preserve_whitespace (SnapdMarkdownParser *self, gboole
 
 /**
  * snapd_markdown_parser_get_preserve_whitespace:
- * @parser: a #SnapdMarkdownParser.
+ * @self: a #SnapdMarkdownParser.
  *
  * Check if paragraph whitespace will be kept intact.
  *
@@ -871,7 +871,7 @@ snapd_markdown_parser_get_preserve_whitespace (SnapdMarkdownParser *self)
 
 /**
  * snapd_markdown_parser_parse:
- * @parser: a #SnapdMarkdownParser.
+ * @self: a #SnapdMarkdownParser.
  * @text: text to parse.
  *
  * Convert text in snapd markdown format to markup.

--- a/snapd-glib/snapd-media.c
+++ b/snapd-glib/snapd-media.c
@@ -55,7 +55,7 @@ snapd_media_new (void)
 
 /**
  * snapd_media_get_media_type:
- * @media: a #SnapdMedia.
+ * @self: a #SnapdMedia.
  *
  * Get the type for this media, e.g. "icon" or "screenshot".
  *
@@ -72,7 +72,7 @@ snapd_media_get_media_type (SnapdMedia *self)
 
 /**
  * snapd_media_get_url:
- * @media: a #SnapdMedia.
+ * @self: a #SnapdMedia.
  *
  * Get the URL for this media, e.g. "http://example.com/media.png"
  *
@@ -89,7 +89,7 @@ snapd_media_get_url (SnapdMedia *self)
 
 /**
  * snapd_media_get_width:
- * @media: a #SnapdMedia.
+ * @self: a #SnapdMedia.
  *
  * Get the width of the media in pixels or 0 if unknown.
  *
@@ -106,7 +106,7 @@ snapd_media_get_width (SnapdMedia *self)
 
 /**
  * snapd_media_get_height:
- * @media: a #SnapdMedia.
+ * @self: a #SnapdMedia.
  *
  * Get the height of the media in pixels or 0 if unknown.
  *

--- a/snapd-glib/snapd-plug-ref.c
+++ b/snapd-glib/snapd-plug-ref.c
@@ -46,7 +46,7 @@ G_DEFINE_TYPE (SnapdPlugRef, snapd_plug_ref, G_TYPE_OBJECT)
 
 /**
  * snapd_plug_ref_get_plug:
- * @plug_ref: a #SnapdPlugRef.
+ * @self: a #SnapdPlugRef.
  *
  * Get the name of the plug.
  *
@@ -63,7 +63,7 @@ snapd_plug_ref_get_plug (SnapdPlugRef *self)
 
 /**
  * snapd_plug_ref_get_snap:
- * @plug_ref: a #SnapdPlugRef.
+ * @self: a #SnapdPlugRef.
  *
  * Get the snap this plug is on.
  *

--- a/snapd-glib/snapd-plug.c
+++ b/snapd-glib/snapd-plug.c
@@ -61,7 +61,7 @@ G_DEFINE_TYPE (SnapdPlug, snapd_plug, G_TYPE_OBJECT)
 
 /**
  * snapd_plug_get_name:
- * @plug: a #SnapdPlug.
+ * @self: a #SnapdPlug.
  *
  * Get the name of this plug.
  *
@@ -78,7 +78,7 @@ snapd_plug_get_name (SnapdPlug *self)
 
 /**
  * snapd_plug_get_snap:
- * @plug: a #SnapdPlug.
+ * @self: a #SnapdPlug.
  *
  * Get the snap this plug is on.
  *
@@ -95,7 +95,7 @@ snapd_plug_get_snap (SnapdPlug *self)
 
 /**
  * snapd_plug_get_interface:
- * @plug: a #SnapdPlug.
+ * @self: a #SnapdPlug.
  *
  * Get the name of the interface this plug provides.
  *
@@ -112,7 +112,7 @@ snapd_plug_get_interface (SnapdPlug *self)
 
 /**
  * snapd_plug_get_attribute_names:
- * @plug: a #SnapdPlug.
+ * @self: a #SnapdPlug.
  * @length: (out) (allow-none): location to write number of attributes or %NULL if not required.
  *
  * Get the names of the attributes this plug has.
@@ -144,7 +144,7 @@ snapd_plug_get_attribute_names (SnapdPlug *self, guint *length)
 
 /**
  * snapd_plug_has_attribute:
- * @plug: a #SnapdPlug.
+ * @self: a #SnapdPlug.
  * @name: an attribute name.
  *
  * Check if this plug has an attribute.
@@ -162,7 +162,7 @@ snapd_plug_has_attribute (SnapdPlug *self, const gchar *name)
 
 /**
  * snapd_plug_get_attribute:
- * @plug: a #SnapdPlug.
+ * @self: a #SnapdPlug.
  * @name: an attribute name.
  *
  * Get an attribute for this interface.
@@ -180,7 +180,7 @@ snapd_plug_get_attribute (SnapdPlug *self, const gchar *name)
 
 /**
  * snapd_plug_get_label:
- * @plug: a #SnapdPlug.
+ * @self: a #SnapdPlug.
  *
  * Get a human readable label for this plug.
  *
@@ -197,7 +197,7 @@ snapd_plug_get_label (SnapdPlug *self)
 
 /**
  * snapd_plug_get_connections:
- * @plug: a #SnapdPlug.
+ * @self: a #SnapdPlug.
  *
  * Get the connections being made with this plug.
  *
@@ -230,7 +230,7 @@ snapd_plug_get_connections (SnapdPlug *self)
 
 /**
  * snapd_plug_get_connected_slots:
- * @plug: a #SnapdPlug.
+ * @self: a #SnapdPlug.
  *
  * Get the slots connected to this plug.
  *

--- a/snapd-glib/snapd-price.c
+++ b/snapd-glib/snapd-price.c
@@ -46,7 +46,7 @@ G_DEFINE_TYPE (SnapdPrice, snapd_price, G_TYPE_OBJECT)
 
 /**
  * snapd_price_get_amount:
- * @price: a #SnapdPrice.
+ * @self: a #SnapdPrice.
  *
  * Get the currency amount for this price, e.g. 0.99.
  *
@@ -63,7 +63,7 @@ snapd_price_get_amount (SnapdPrice *self)
 
 /**
  * snapd_price_get_currency:
- * @price: a #SnapdPrice.
+ * @self: a #SnapdPrice.
  *
  * Get the currency this price is in, e.g. "NZD".
  *

--- a/snapd-glib/snapd-screenshot.c
+++ b/snapd-glib/snapd-screenshot.c
@@ -53,7 +53,7 @@ snapd_screenshot_new (void)
 
 /**
  * snapd_screenshot_get_url:
- * @screenshot: a #SnapdScreenshot.
+ * @self: a #SnapdScreenshot.
  *
  * Get the URL for this screenshot, e.g. "http://example.com/screenshot.png"
  *
@@ -70,7 +70,7 @@ snapd_screenshot_get_url (SnapdScreenshot *self)
 
 /**
  * snapd_screenshot_get_width:
- * @screenshot: a #SnapdScreenshot.
+ * @self: a #SnapdScreenshot.
  *
  * Get the width of the screenshot in pixels or 0 if unknown.
  *
@@ -87,7 +87,7 @@ snapd_screenshot_get_width (SnapdScreenshot *self)
 
 /**
  * snapd_screenshot_get_height:
- * @screenshot: a #SnapdScreenshot.
+ * @self: a #SnapdScreenshot.
  *
  * Get the height of the screenshot in pixels or 0 if unknown.
  *

--- a/snapd-glib/snapd-slot-ref.c
+++ b/snapd-glib/snapd-slot-ref.c
@@ -46,7 +46,7 @@ G_DEFINE_TYPE (SnapdSlotRef, snapd_slot_ref, G_TYPE_OBJECT)
 
 /**
  * snapd_slot_ref_get_slot:
- * @slot_ref: a #SnapdSlotRef.
+ * @self: a #SnapdSlotRef.
  *
  * Get the name of the slot.
  *
@@ -63,7 +63,7 @@ snapd_slot_ref_get_slot (SnapdSlotRef *self)
 
 /**
  * snapd_slot_ref_get_snap:
- * @slot_ref: a #SnapdSlotRef.
+ * @self: a #SnapdSlotRef.
  *
  * Get the snap this slot is on.
  *

--- a/snapd-glib/snapd-slot.c
+++ b/snapd-glib/snapd-slot.c
@@ -61,7 +61,7 @@ G_DEFINE_TYPE (SnapdSlot, snapd_slot, G_TYPE_OBJECT)
 
 /**
  * snapd_slot_get_name:
- * @slot: a #SnapdSlot.
+ * @self: a #SnapdSlot.
  *
  * Get the name of this slot.
  *
@@ -78,7 +78,7 @@ snapd_slot_get_name (SnapdSlot *self)
 
 /**
  * snapd_slot_get_snap:
- * @slot: a #SnapdSlot.
+ * @self: a #SnapdSlot.
  *
  * Get the snap this slot is on.
  *
@@ -95,7 +95,7 @@ snapd_slot_get_snap (SnapdSlot *self)
 
 /**
  * snapd_slot_get_interface:
- * @slot: a #SnapdSlot.
+ * @self: a #SnapdSlot.
  *
  * Get the name of the interface this slot accepts.
  *
@@ -112,7 +112,7 @@ snapd_slot_get_interface (SnapdSlot *self)
 
 /**
  * snapd_slot_get_attribute_names:
- * @slot: a #SnapdSlot.
+ * @self: a #SnapdSlot.
  * @length: (out) (allow-none): location to write number of attributes or %NULL if not required.
  *
  * Get the names of the attributes this slot has.
@@ -144,7 +144,7 @@ snapd_slot_get_attribute_names (SnapdSlot *self, guint *length)
 
 /**
  * snapd_slot_has_attribute:
- * @slot: a #SnapdSlot.
+ * @self: a #SnapdSlot.
  * @name: an attribute name.
  *
  * Check if this slot has an attribute.
@@ -162,7 +162,7 @@ snapd_slot_has_attribute (SnapdSlot *self, const gchar *name)
 
 /**
  * snapd_slot_get_attribute:
- * @slot: a #SnapdSlot.
+ * @self: a #SnapdSlot.
  * @name: an attribute name.
  *
  * Get an attribute for this interface.
@@ -180,7 +180,7 @@ snapd_slot_get_attribute (SnapdSlot *self, const gchar *name)
 
 /**
  * snapd_slot_get_label:
- * @slot: a #SnapdSlot.
+ * @self: a #SnapdSlot.
  *
  * Get a human readable label for this slot.
  *
@@ -197,7 +197,7 @@ snapd_slot_get_label (SnapdSlot *self)
 
 /**
  * snapd_slot_get_connections:
- * @slot: a #SnapdSlot.
+ * @self: a #SnapdSlot.
  *
  * Get the connections being made with this slot.
  *
@@ -230,7 +230,7 @@ snapd_slot_get_connections (SnapdSlot *self)
 
 /**
  * snapd_slot_get_connected_plugs:
- * @slot: a #SnapdSlot.
+ * @self: a #SnapdSlot.
  *
  * Get the plugs connected to this slot.
  *

--- a/snapd-glib/snapd-snap.c
+++ b/snapd-glib/snapd-snap.c
@@ -124,7 +124,7 @@ G_DEFINE_TYPE (SnapdSnap, snapd_snap, G_TYPE_OBJECT)
 
 /**
  * snapd_snap_get_apps:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the apps this snap provides.
  *
@@ -141,7 +141,7 @@ snapd_snap_get_apps (SnapdSnap *self)
 
 /**
  * snapd_snap_get_base:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the base snap this snap uses.
  *
@@ -158,7 +158,7 @@ snapd_snap_get_base (SnapdSnap *self)
 
 /**
  * snapd_snap_get_broken:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the reason this snap is broken.
  *
@@ -175,7 +175,7 @@ snapd_snap_get_broken (SnapdSnap *self)
 
 /**
  * snapd_snap_get_categories:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Gets the categories this snap belongs to.
  *
@@ -192,7 +192,7 @@ snapd_snap_get_categories (SnapdSnap *self)
 
 /**
  * snapd_snap_get_channel:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the channel this snap is from, e.g. "stable".
  *
@@ -209,7 +209,7 @@ snapd_snap_get_channel (SnapdSnap *self)
 
 /**
  * snapd_snap_get_channels:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Gets the available channels for this snap.
  *
@@ -241,7 +241,7 @@ parse_risk (const gchar *risk)
 
 /**
  * snapd_snap_match_channel:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  * @name: a channel name.
  *
  * Finds the available channel that best matches the given name.
@@ -287,7 +287,7 @@ snapd_snap_match_channel (SnapdSnap *self, const gchar *name)
 
 /**
  * snapd_snap_get_common_ids:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get common IDs associated with this snap.
  *
@@ -304,7 +304,7 @@ snapd_snap_get_common_ids (SnapdSnap *self)
 
 /**
  * snapd_snap_get_confinement:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the confinement this snap is using, e.g. %SNAPD_CONFINEMENT_STRICT.
  *
@@ -321,7 +321,7 @@ snapd_snap_get_confinement (SnapdSnap *self)
 
 /**
  * snapd_snap_get_contact:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the means of contacting the snap developer, e.g. "mailto:developer@example.com".
  *
@@ -338,7 +338,7 @@ snapd_snap_get_contact (SnapdSnap *self)
 
 /**
  * snapd_snap_get_description:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get a multi-line description of this snap. The description is formatted using
  * a subset of Markdown. To parse this use a #SnapdMarkdownParser.
@@ -356,7 +356,7 @@ snapd_snap_get_description (SnapdSnap *self)
 
 /**
  * snapd_snap_get_developer:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the developer who created this snap.
  *
@@ -374,7 +374,7 @@ snapd_snap_get_developer (SnapdSnap *self)
 
 /**
  * snapd_snap_get_devmode:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get if this snap is running in developer mode.
  *
@@ -391,7 +391,7 @@ snapd_snap_get_devmode (SnapdSnap *self)
 
 /**
  * snapd_snap_get_download_size:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the download size of this snap or 0 if unknown.
  *
@@ -408,7 +408,7 @@ snapd_snap_get_download_size (SnapdSnap *self)
 
 /**
  * snapd_snap_get_hold:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the date this snap will re-enable automatic refreshing or %NULL if no hold is present.
  *
@@ -426,7 +426,7 @@ snapd_snap_get_hold (SnapdSnap *self)
 
 /**
  * snapd_snap_get_icon:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the icon for this Snap, either a URL or an absolute path to retrieve it
  * from snapd directly.
@@ -444,7 +444,7 @@ snapd_snap_get_icon (SnapdSnap *self)
 
 /**
  * snapd_snap_get_id:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Gets the unique ID for this snap.
  *
@@ -461,7 +461,7 @@ snapd_snap_get_id (SnapdSnap *self)
 
 /**
  * snapd_snap_get_install_date:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the date this snap was installed or %NULL if unknown.
  *
@@ -478,7 +478,7 @@ snapd_snap_get_install_date (SnapdSnap *self)
 
 /**
  * snapd_snap_get_installed_size:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the installed size of this snap or 0 if unknown.
  *
@@ -495,7 +495,7 @@ snapd_snap_get_installed_size (SnapdSnap *self)
 
 /**
  * snapd_snap_get_jailmode:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get if this snap is running in enforced confinement (jail) mode.
  *
@@ -512,7 +512,7 @@ snapd_snap_get_jailmode (SnapdSnap *self)
 
 /**
  * snapd_snap_get_license:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Gets the SPDX license expression for this snap, e.g. "GPL-3.0+".
  *
@@ -529,7 +529,7 @@ snapd_snap_get_license (SnapdSnap *self)
 
 /**
  * snapd_snap_get_media:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get media that is associated with this snap.
  *
@@ -546,7 +546,7 @@ snapd_snap_get_media (SnapdSnap *self)
 
 /**
  * snapd_snap_get_mounted_from:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Gets the path this snap is mounted from, which is a .snap file for installed
  * snaps and a directory for snaps in try mode.
@@ -564,7 +564,7 @@ snapd_snap_get_mounted_from (SnapdSnap *self)
 
 /**
  * snapd_snap_get_title:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the title for this snap. If not available use the snap name instead.
  *
@@ -581,7 +581,7 @@ snapd_snap_get_title (SnapdSnap *self)
 
 /**
  * snapd_snap_get_name:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the name of this snap. This is used to reference this snap, e.g. for
  * installing / removing.
@@ -599,7 +599,7 @@ snapd_snap_get_name (SnapdSnap *self)
 
 /**
  * snapd_snap_get_prices:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the prices that this snap can be purchased at.
  *
@@ -616,7 +616,7 @@ snapd_snap_get_prices (SnapdSnap *self)
 
 /**
  * snapd_snap_get_private:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get if this snap is only available to the developer.
  *
@@ -633,7 +633,7 @@ snapd_snap_get_private (SnapdSnap *self)
 
 /**
  * snapd_snap_get_publisher_display_name:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the display name of the publisher who created this snap.
  *
@@ -650,7 +650,7 @@ snapd_snap_get_publisher_display_name (SnapdSnap *self)
 
 /**
  * snapd_snap_get_publisher_id:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the ID of the publisher who created this snap.
  *
@@ -667,7 +667,7 @@ snapd_snap_get_publisher_id (SnapdSnap *self)
 
 /**
  * snapd_snap_get_publisher_username:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the username of the publisher who created this snap.
  *
@@ -684,7 +684,7 @@ snapd_snap_get_publisher_username (SnapdSnap *self)
 
 /**
  * snapd_snap_get_publisher_validation:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the validation for the snap publisher, e.g. %SNAPD_PUBLISHER_VALIDATION_VERIFIED
  *
@@ -701,7 +701,7 @@ snapd_snap_get_publisher_validation (SnapdSnap *self)
 
 /**
  * snapd_snap_get_revision:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the revision for this snap. The format of the string is undefined.
  * See also snapd_snap_get_version().
@@ -719,7 +719,7 @@ snapd_snap_get_revision (SnapdSnap *self)
 
 /**
  * snapd_snap_get_screenshots:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the screenshots that are available for this snap.
  *
@@ -737,7 +737,7 @@ snapd_snap_get_screenshots (SnapdSnap *self)
 
 /**
  * snapd_snap_get_snap_type:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the type of snap, e.g. %SNAPD_SNAP_TYPE_APP
  *
@@ -754,7 +754,7 @@ snapd_snap_get_snap_type (SnapdSnap *self)
 
 /**
  * snapd_snap_get_status:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the current status of this snap, e.g. SNAPD_SNAP_STATUS_INSTALLED.
  *
@@ -771,7 +771,7 @@ snapd_snap_get_status (SnapdSnap *self)
 
 /**
  * snapd_snap_get_store_url:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get a URL to the web snap store, e.g. "https://snapcraft.io/example"
  *
@@ -788,7 +788,7 @@ snapd_snap_get_store_url (SnapdSnap *self)
 
 /**
  * snapd_snap_get_summary:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get a single line summary for this snap, e.g. "Best app ever!".
  *
@@ -805,7 +805,7 @@ snapd_snap_get_summary (SnapdSnap *self)
 
 /**
  * snapd_snap_get_tracking_channel:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the channel that updates will be installed from, e.g. "stable".
  *
@@ -822,7 +822,7 @@ snapd_snap_get_tracking_channel (SnapdSnap *self)
 
 /**
  * snapd_snap_get_tracks:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the tracks that are available.
  *
@@ -839,7 +839,7 @@ snapd_snap_get_tracks (SnapdSnap *self)
 
 /**
  * snapd_snap_get_trymode:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get if this snap is running in try mode (installed locally and able to be
  * directly modified).
@@ -857,7 +857,7 @@ snapd_snap_get_trymode (SnapdSnap *self)
 
 /**
  * snapd_snap_get_version:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the version for this snap. The format of the string is undefined.
  * See also snapd_snap_get_revision().
@@ -875,7 +875,7 @@ snapd_snap_get_version (SnapdSnap *self)
 
 /**
  * snapd_snap_get_website:
- * @snap: a #SnapdSnap.
+ * @self: a #SnapdSnap.
  *
  * Get the website of the snap developer, e.g. "http://example.com".
  *

--- a/snapd-glib/snapd-system-information.c
+++ b/snapd-glib/snapd-system-information.c
@@ -80,7 +80,7 @@ G_DEFINE_TYPE (SnapdSystemInformation, snapd_system_information, G_TYPE_OBJECT)
 
 /**
  * snapd_system_information_get_architecture:
- * @system_information: a #SnapdSystemInformation.
+ * @self: a #SnapdSystemInformation.
  *
  * Get the architecture this system is using, e.g. "amd64".
  *
@@ -97,7 +97,7 @@ snapd_system_information_get_architecture (SnapdSystemInformation *self)
 
 /**
  * snapd_system_information_get_binaries_directory:
- * @system_information: a #SnapdSystemInformation.
+ * @self: a #SnapdSystemInformation.
  *
  * Get the directory snap binaries are stored, e.g. "/snap/bin".
  *
@@ -114,7 +114,7 @@ snapd_system_information_get_binaries_directory (SnapdSystemInformation *self)
 
 /**
  * snapd_system_information_get_build_id:
- * @system_information: a #SnapdSystemInformation.
+ * @self: a #SnapdSystemInformation.
  *
  * Gets the unique build ID for the snap build, e.g. "efdd0b5e69b0742fa5e5bad0771df4d1df2459d1"
  *
@@ -131,7 +131,7 @@ snapd_system_information_get_build_id (SnapdSystemInformation *self)
 
 /**
  * snapd_system_information_get_confinement:
- * @system_information: a #SnapdSystemInformation.
+ * @self: a #SnapdSystemInformation.
  *
  * Get the level of confinement the system supports, e.g. %SNAPD_SYSTEM_CONFINEMENT_STRICT.
  *
@@ -148,7 +148,7 @@ snapd_system_information_get_confinement (SnapdSystemInformation *self)
 
 /**
  * snapd_system_information_get_kernel_version:
- * @system_information: a #SnapdSystemInformation.
+ * @self: a #SnapdSystemInformation.
  *
  * Get the version of the kernel snapd is running on, e.g. "4.10.0-15-generic".
  *
@@ -165,7 +165,7 @@ snapd_system_information_get_kernel_version (SnapdSystemInformation *self)
 
 /**
  * snapd_system_information_get_managed:
- * @system_information: a #SnapdSystemInformation.
+ * @self: a #SnapdSystemInformation.
  *
  * Get if snapd is running on a managed system.
  *
@@ -182,7 +182,7 @@ snapd_system_information_get_managed (SnapdSystemInformation *self)
 
 /**
  * snapd_system_information_get_mount_directory:
- * @system_information: a #SnapdSystemInformation.
+ * @self: a #SnapdSystemInformation.
  *
  * Get the directory snaps are mounted, e.g. "/snap".
  *
@@ -199,7 +199,7 @@ snapd_system_information_get_mount_directory (SnapdSystemInformation *self)
 
 /**
  * snapd_system_information_get_on_classic:
- * @system_information: a #SnapdSystemInformation.
+ * @self: a #SnapdSystemInformation.
  *
  * Get if this system is a classic system.
  *
@@ -216,7 +216,7 @@ snapd_system_information_get_on_classic (SnapdSystemInformation *self)
 
 /**
  * snapd_system_information_get_os_id:
- * @system_information: a #SnapdSystemInformation.
+ * @self: a #SnapdSystemInformation.
  *
  * Get the operating system ID, e.g. "ubuntu".
  *
@@ -233,7 +233,7 @@ snapd_system_information_get_os_id (SnapdSystemInformation *self)
 
 /**
  * snapd_system_information_get_os_version:
- * @system_information: a #SnapdSystemInformation.
+ * @self: a #SnapdSystemInformation.
  *
  * Get the operating system version, e.g. "16.04".
  *
@@ -250,7 +250,7 @@ snapd_system_information_get_os_version (SnapdSystemInformation *self)
 
 /**
  * snapd_system_information_get_refresh_hold:
- * @system_information: a #SnapdSystemInformation.
+ * @self: a #SnapdSystemInformation.
  *
  * Get the time refreshes will be applied at, or %NULL if they are applied immediately.
  *
@@ -267,7 +267,7 @@ snapd_system_information_get_refresh_hold (SnapdSystemInformation *self)
 
 /**
  * snapd_system_information_get_refresh_last:
- * @system_information: a #SnapdSystemInformation.
+ * @self: a #SnapdSystemInformation.
  *
  * Get the time the last refresh occurred, or %NULL if has not occurred.
  *
@@ -284,7 +284,7 @@ snapd_system_information_get_refresh_last (SnapdSystemInformation *self)
 
 /**
  * snapd_system_information_get_refresh_next:
- * @system_information: a #SnapdSystemInformation.
+ * @self: a #SnapdSystemInformation.
  *
  * Get the time the next refresh is scheduled for, or %NULL if none has been scheduled.
  *
@@ -301,7 +301,7 @@ snapd_system_information_get_refresh_next (SnapdSystemInformation *self)
 
 /**
  * snapd_system_information_get_refresh_schedule:
- * @system_information: a #SnapdSystemInformation.
+ * @self: a #SnapdSystemInformation.
  *
  * Get the schedule when snap refreshes will occur.
  *
@@ -318,7 +318,7 @@ snapd_system_information_get_refresh_schedule (SnapdSystemInformation *self)
 
 /**
  * snapd_system_information_get_refresh_timer:
- * @system_information: a #SnapdSystemInformation.
+ * @self: a #SnapdSystemInformation.
  *
  * Get the timer that refreshes are running to.
  *
@@ -335,7 +335,7 @@ snapd_system_information_get_refresh_timer (SnapdSystemInformation *self)
 
 /**
  * snapd_system_information_get_sandbox_features:
- * @system_information: a #SnapdSystemInformation.
+ * @self: a #SnapdSystemInformation.
  *
  * Gets the sandbox features that snapd provides. Each backend in snapd provides
  * a list of features that it supports. For example, the "confinement-options"
@@ -354,7 +354,7 @@ snapd_system_information_get_sandbox_features (SnapdSystemInformation *self)
 
 /**
  * snapd_system_information_get_series:
- * @system_information: a #SnapdSystemInformation.
+ * @self: a #SnapdSystemInformation.
  *
  * Get the series of snapd running, e.g. "16".
  *
@@ -371,7 +371,7 @@ snapd_system_information_get_series (SnapdSystemInformation *self)
 
 /**
  * snapd_system_information_get_store:
- * @system_information: a #SnapdSystemInformation.
+ * @self: a #SnapdSystemInformation.
  *
  * Get the store being used by snapd, e.g. "Ubuntu"
  *
@@ -388,7 +388,7 @@ snapd_system_information_get_store (SnapdSystemInformation *self)
 
 /**
  * snapd_system_information_get_version:
- * @system_information: a #SnapdSystemInformation.
+ * @self: a #SnapdSystemInformation.
  *
  * Get the version of snapd running, e.g. "2.11+ppa174-1".
  *

--- a/snapd-glib/snapd-task.c
+++ b/snapd-glib/snapd-task.c
@@ -62,7 +62,7 @@ G_DEFINE_TYPE (SnapdTask, snapd_task, G_TYPE_OBJECT)
 
 /**
  * snapd_task_get_id:
- * @task: a #SnapdTask.
+ * @self: a #SnapdTask.
  *
  * Get the unique ID for this task.
  *
@@ -83,7 +83,7 @@ snapd_task_get_id (SnapdTask *self)
 
 /**
  * snapd_task_get_kind:
- * @task: a #SnapdTask.
+ * @self: a #SnapdTask.
  *
  * Gets the kind of task this is.
  *
@@ -104,7 +104,7 @@ snapd_task_get_kind (SnapdTask *self)
 
 /**
  * snapd_task_get_summary:
- * @task: a #SnapdTask.
+ * @self: a #SnapdTask.
  *
  * Get a human readable description of the task.
  *
@@ -125,7 +125,7 @@ snapd_task_get_summary (SnapdTask *self)
 
 /**
  * snapd_task_get_status:
- * @task: a #SnapdTask.
+ * @self: a #SnapdTask.
  *
  * Get the status of the task.
  *
@@ -146,7 +146,7 @@ snapd_task_get_status (SnapdTask *self)
 
 /**
  * snapd_task_get_ready:
- * @task: a #SnapdTask.
+ * @self: a #SnapdTask.
  *
  * Get if this task is completed.
  *
@@ -168,7 +168,7 @@ snapd_task_get_ready (SnapdTask *self)
 
 /**
  * snapd_task_get_progress_label:
- * @task: a #SnapdTask.
+ * @self: a #SnapdTask.
  *
  * Get the the label associated with the progress.
  *
@@ -189,7 +189,7 @@ snapd_task_get_progress_label (SnapdTask *self)
 
 /**
  * snapd_task_get_progress_done:
- * @task: a #SnapdTask.
+ * @self: a #SnapdTask.
  *
  * Get the the number of items completed in this task.
  *
@@ -210,7 +210,7 @@ snapd_task_get_progress_done (SnapdTask *self)
 
 /**
  * snapd_task_get_progress_total:
- * @task: a #SnapdTask.
+ * @self: a #SnapdTask.
  *
  * Get the the total number of items to be completed in this task.
  *
@@ -231,7 +231,7 @@ snapd_task_get_progress_total (SnapdTask *self)
 
 /**
  * snapd_task_get_spawn_time:
- * @task: a #SnapdTask.
+ * @self: a #SnapdTask.
  *
  * Get the time this task started.
  *
@@ -252,7 +252,7 @@ snapd_task_get_spawn_time (SnapdTask *self)
 
 /**
  * snapd_task_get_ready_time:
- * @task: a #SnapdTask.
+ * @self: a #SnapdTask.
  *
  * Get the time this task completed or %NULL if not yet completed.
  *

--- a/snapd-glib/snapd-user-information.c
+++ b/snapd-glib/snapd-user-information.c
@@ -53,7 +53,7 @@ G_DEFINE_TYPE (SnapdUserInformation, snapd_user_information, G_TYPE_OBJECT)
 
 /**
  * snapd_user_information_get_id:
- * @user_information: a #SnapdUserInformation.
+ * @self: a #SnapdUserInformation.
  *
  * Get the id for this account.
  *
@@ -70,7 +70,7 @@ snapd_user_information_get_id (SnapdUserInformation *self)
 
 /**
  * snapd_user_information_get_username:
- * @user_information: a #SnapdUserInformation.
+ * @self: a #SnapdUserInformation.
  *
  * Get the local username for this account.
  *
@@ -87,7 +87,7 @@ snapd_user_information_get_username (SnapdUserInformation *self)
 
 /**
  * snapd_user_information_get_email:
- * @user_information: a #SnapdUserInformation.
+ * @self: a #SnapdUserInformation.
  *
  * Get the email address for this account.
  *
@@ -104,7 +104,7 @@ snapd_user_information_get_email (SnapdUserInformation *self)
 
 /**
  * snapd_user_information_get_ssh_keys:
- * @user_information: a #SnapdUserInformation.
+ * @self: a #SnapdUserInformation.
  *
  * Get the SSH keys added to this account.
  *
@@ -121,7 +121,7 @@ snapd_user_information_get_ssh_keys (SnapdUserInformation *self)
 
 /**
  * snapd_user_information_get_auth_data:
- * @user_information: a #SnapdUserInformation.
+ * @self: a #SnapdUserInformation.
  *
  * Get the email address for this account.
  *


### PR DESCRIPTION
The gobject-introspection documentation have incorrect parameter names for the "self" parameter. Probably, in origin specific names were used, and after that they were changed to "self", but the documentation comments weren't updated.

This patch fixes it.