### PR TITLE
snapd-qt/meson.build: Install Notice header

### DIFF
--- a/snapd-qt/meson.build
+++ b/snapd-qt/meson.build
@@ -131,6 +131,7 @@ source_alias_h = [
   'Snapd/MarkdownNode',
   'Snapd/MarkdownParser',
   'Snapd/Media',
+  'Snapd/Notice',
   'Snapd/Plug',
   'Snapd/PlugRef',
   'Snapd/Price',


### PR DESCRIPTION
Otherwise compilation of Discover with snap back-end fails with:

```
FAILED: libdiscover/backends/SnapBackend/libsnapclient/CMakeFiles/libsnap_helper.dir/SnapAuthHelper.cpp.o
/usr/bin/x86_64-pc-linux-gnu-g++ -DKCOREADDONS_LIB -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_FROM_BYTEARRAY -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_NO_FOREACH -DQT_NO_KEYWORDS -DQT_NO_NARROWING_CONVERSIONS_IN_CONNECT -DQT_NO_SIGNALS_SLOTS_KEYWORDS -DQT_NO_URL_CAST_FROM_STRING -DQT_STRICT_ITERATORS -DQT_USE_QSTRINGBUILDER -DTRANSLATION_DOMAIN=\"libdiscover\" -D_GNU_SOURCE -D_LARGEFILE64_SOURCE -I/tmp/portage/kde-plasma/discover-6.0.4-r1/work/discover-6.0.4_build/libdiscover/backends/SnapBackend/libsnapclient -I/tmp/portage/kde-plasma/discover-6.0.4-r1/work/discover-6.0.4/libdiscover/backends/SnapBackend/libsnapclient -I/tmp/portage/kde-plasma/discover-6.0.4-r1/work/discover-6.0.4_build/libdiscover/backends/SnapBackend/libsnapclient/libsnap_helper_autogen/include -isystem /usr/include/qt6/QtNetwork -isystem /usr/include/qt6 -isystem /usr/include/qt6/QtCore -isystem /usr/lib64/qt6/mkspecs/linux-g++ -isystem /usr/include/KF6/KAuthCore -isystem /usr/include/KF6/KAuth -isystem /usr/include/qt6/QtGui -isystem /usr/include/KF6/KCoreAddons -isystem /usr/include/snapd-qt-2  -DQT_NO_DEBUG -O3 -pipe -march=skylake -mtune=skylake -flto=16 -fno-operator-names -fno-exceptions -Wall -Wextra -Wcast-align -Wchar-subscripts -Wformat-security -Wno-long-long -Wpointer-arith -Wundef -Wnon-virtual-dtor -Woverloaded-virtual -Werror=return-type -Werror=init-self -Wvla -Wdate-time -Wsuggest-override -Wlogical-op -pedantic -Wzero-as-null-pointer-constant -Wmissing-include-dirs -fdiagnostics-color=always -std=c++17 -fvisibility=hidden -fvisibility-inlines-hidden -fPIC -MD -MT libdiscover/backends/SnapBackend/libsnapclient/CMakeFiles/libsnap_helper.dir/SnapAuthHelper.cpp.o -MF libdiscover/backends/SnapBackend/libsnapclient/CMakeFiles/libsnap_helper.dir/SnapAuthHelper.cpp.o.d -o libdiscover/backends/SnapBackend/libsnapclient/CMakeFiles/libsnap_helper.dir/SnapAuthHelper.cpp.o -c /tmp/portage/kde-plasma/discover-6.0.4-r1/work/discover-6.0.4/libdiscover/backends/SnapBackend/libsnapclient/SnapAuthHelper.cpp
In file included from /usr/include/snapd-qt-2/Snapd/Client:1,
from /tmp/portage/kde-plasma/discover-6.0.4-r1/work/discover-6.0.4/libdiscover/backends/SnapBackend/libsnapclient/SnapAuthHelper.cpp:14:
/usr/include/snapd-qt-2/Snapd/client.h:24:10: fatal error: Snapd/Notice: No such file or directory
24 | #include <Snapd/Notice>
|          ^~~~~~~~~~~~~~
compilation terminated.
```