### PR TITLE
Added support for data field in SnapdTask

### DIFF
--- a/snapd-glib/meson.build
+++ b/snapd-glib/meson.build
@@ -38,6 +38,7 @@ source_h = [
   'snapd-snap.h',
   'snapd-system-information.h',
   'snapd-task.h',
+  'snapd-task-data.h',
   'snapd-user-information.h',
   'snapd-version.h',
 ]
@@ -120,6 +121,7 @@ source_c = [
   'snapd-snap.c',
   'snapd-system-information.c',
   'snapd-task.c',
+  'snapd-task-data.c',
   'snapd-user-information.c',
 ]
 

--- a/snapd-glib/requests/snapd-json.c
+++ b/snapd-glib/requests/snapd-json.c
@@ -763,14 +763,6 @@ _snapd_json_parse_notice (JsonNode *node, GError **error)
     return retlist;
 }
 
-static void
-add_affected_snap_to_list (JsonArray *array, guint index, JsonNode *element, void *data)
-{
-    GPtrArray *list = (GPtrArray *) data;
-    const gchar *snap_name = json_array_get_string_element (array, index);
-    g_ptr_array_add (list, g_strdup(snap_name));
-}
-
 SnapdChange *
 _snapd_json_parse_change (JsonNode *node, GError **error)
 {
@@ -808,12 +800,11 @@ _snapd_json_parse_change (JsonNode *node, GError **error)
                     g_set_error (error,
                                 SNAPD_ERROR,
                                 SNAPD_ERROR_READ_FAILED,
-                                "Unexpected change type");
+                                "Unexpected affected-snaps type");
                     return NULL;
                 }
                 JsonArray *affected_snaps = json_node_get_array (affected_snaps_node);
-                GPtrArray *affected_snaps_array = g_ptr_array_new_full(json_array_get_length (affected_snaps), g_free);
-                json_array_foreach_element (affected_snaps, add_affected_snap_to_list, affected_snaps_array);
+                g_auto(GStrv) affected_snaps_array = create_str_array_from_jsonarray (affected_snaps);
                 task_data = g_object_new (SNAPD_TYPE_TASK_DATA,
                                           "affected-snaps", affected_snaps_array,
                                           NULL);

--- a/snapd-glib/requests/snapd-json.c
+++ b/snapd-glib/requests/snapd-json.c
@@ -763,6 +763,14 @@ _snapd_json_parse_notice (JsonNode *node, GError **error)
     return retlist;
 }
 
+static void
+add_affected_snap_to_list (JsonArray *array, guint index, JsonNode *element, void *data)
+{
+    GPtrArray *list = (GPtrArray *) data;
+    const gchar *snap_name = json_array_get_string_element (array, index);
+    g_ptr_array_add (list, g_strdup(snap_name));
+}
+
 SnapdChange *
 _snapd_json_parse_change (JsonNode *node, GError **error)
 {
@@ -791,6 +799,26 @@ _snapd_json_parse_change (JsonNode *node, GError **error)
         JsonObject *progress = _snapd_json_get_object (object, "progress");
         g_autoptr(GDateTime) spawn_time = _snapd_json_get_date_time (object, "spawn-time", NULL);
         g_autoptr(GDateTime) ready_time = _snapd_json_get_date_time (object, "ready-time", NULL);
+        JsonObject *data = _snapd_json_get_object (object, "data");
+        g_autoptr(SnapdTaskData) task_data = NULL;
+        if (data != NULL) {
+            JsonNode *affected_snaps_node = json_object_get_member (data, "affected-snaps");
+            if (affected_snaps_node != NULL) {
+                if (json_node_get_value_type (affected_snaps_node) != JSON_TYPE_ARRAY) {
+                    g_set_error (error,
+                                SNAPD_ERROR,
+                                SNAPD_ERROR_READ_FAILED,
+                                "Unexpected change type");
+                    return NULL;
+                }
+                JsonArray *affected_snaps = json_node_get_array (affected_snaps_node);
+                GPtrArray *affected_snaps_array = g_ptr_array_new_full(json_array_get_length (affected_snaps), g_free);
+                json_array_foreach_element (affected_snaps, add_affected_snap_to_list, affected_snaps_array);
+                task_data = g_object_new (SNAPD_TYPE_TASK_DATA,
+                                          "affected-snaps", affected_snaps_array,
+                                          NULL);
+            }
+        }
 
         g_autoptr(SnapdTask) t = g_object_new (SNAPD_TYPE_TASK,
                                                "id", _snapd_json_get_string (object, "id", NULL),
@@ -802,6 +830,7 @@ _snapd_json_parse_change (JsonNode *node, GError **error)
                                                "progress-total", progress != NULL ? _snapd_json_get_int (progress, "total", 0) : 0,
                                                "spawn-time", spawn_time,
                                                "ready-time", ready_time,
+                                               "data", task_data,
                                                NULL);
         g_ptr_array_add (tasks, g_steal_pointer (&t));
     }

--- a/snapd-glib/snapd-task-data.c
+++ b/snapd-glib/snapd-task-data.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2024 Canonical Ltd.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2 or version 3 of the License.
+ * See http://www.gnu.org/copyleft/lgpl.html the full text of the license.
+ */
+
+#include <string.h>
+
+#include "snapd-task-data.h"
+
+/**
+ * SECTION: snapd-task-data
+ * @short_description: Task extra data
+ * @include: snapd-glib/snapd-glib.h
+ *
+ * A #SnapdTaskData contains extra information on a task in a #SnapdChange.
+ */
+
+/**
+ * SnapdTaskData:
+ *
+ * #SnapdTaskData contains extra information for a task in a Snap transaction.
+ *
+ * Since: 1.66
+ */
+
+struct _SnapdTaskData
+{
+    GObject parent_instance;
+    GPtrArray *affected_snaps;
+};
+
+enum
+{
+    PROP_ID = 1,
+    PROP_AFFECTED_SNAPS,
+    PROP_LAST
+};
+
+G_DEFINE_TYPE (SnapdTaskData, snapd_task_data, G_TYPE_OBJECT)
+
+
+/**
+ * snapd_task_data_get_affected_snaps:
+ * @task_data: a #SnapdTaskData.
+ *
+ * Get the list of snaps that are affected by this task, or %NULL if snapd doesn't send this data.
+ *
+ * Returns: (transfer full) (allow-none) (element-type gchar*): a #GPtrArray or %NULL.
+ *
+ * Since: 1.66
+ */
+GPtrArray *
+snapd_task_data_get_affected_snaps (SnapdTaskData *self)
+{
+    g_return_val_if_fail (SNAPD_IS_TASK_DATA (self), NULL);
+    return g_ptr_array_ref(self->affected_snaps);
+}
+
+static void
+snapd_task_data_set_property (GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
+{
+    SnapdTaskData *self = SNAPD_TASK_DATA (object);
+
+    switch (prop_id) {
+    case PROP_AFFECTED_SNAPS:
+        g_clear_pointer (&self->affected_snaps, g_ptr_array_unref);
+        if (g_value_get_boxed (value) != NULL)
+            self->affected_snaps = g_ptr_array_ref (g_value_get_boxed (value));
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+        break;
+    }
+}
+
+static void
+snapd_task_data_get_property (GObject *object, guint prop_id, GValue *value, GParamSpec *pspec)
+{
+    SnapdTaskData *self = SNAPD_TASK_DATA (object);
+
+    switch (prop_id) {
+    case PROP_AFFECTED_SNAPS:
+        g_value_set_boxed (value, self->affected_snaps);
+        break;
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+        break;
+    }
+}
+
+static void
+snapd_task_data_finalize (GObject *object)
+{
+    SnapdTaskData *self = SNAPD_TASK_DATA (object);
+
+    g_clear_pointer (&self->affected_snaps, g_ptr_array_unref);
+    G_OBJECT_CLASS (snapd_task_data_parent_class)->finalize (object);
+}
+
+static void
+snapd_task_data_class_init (SnapdTaskDataClass *klass)
+{
+    GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+    gobject_class->set_property = snapd_task_data_set_property;
+    gobject_class->get_property = snapd_task_data_get_property;
+    gobject_class->finalize = snapd_task_data_finalize;
+
+    g_object_class_install_property (gobject_class,
+                                     PROP_AFFECTED_SNAPS,
+                                     g_param_spec_boxed ("affected-snaps",
+                                                         "affected-snaps",
+                                                         "Snaps affected by this task",
+                                                         G_TYPE_PTR_ARRAY,
+                                                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+}
+
+static void
+snapd_task_data_init (SnapdTaskData *self)
+{
+}

--- a/snapd-glib/snapd-task-data.h
+++ b/snapd-glib/snapd-task-data.h
@@ -22,7 +22,7 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE (SnapdTaskData, snapd_task_data, SNAPD, TASK_DATA, GObject)
 
-GPtrArray *snapd_task_data_get_affected_snaps              (SnapdTaskData *task_data);
+GStrv snapd_task_data_get_affected_snaps              (SnapdTaskData *task_data);
 
 G_END_DECLS
 

--- a/snapd-glib/snapd-task-data.h
+++ b/snapd-glib/snapd-task-data.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 Canonical Ltd.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2 or version 3 of the License.
+ * See http://www.gnu.org/copyleft/lgpl.html the full text of the license.
+ */
+
+#ifndef __SNAPD_TASK_DATA_H__
+#define __SNAPD_TASK_DATA_H__
+
+#if !defined(__SNAPD_GLIB_INSIDE__) && !defined(SNAPD_COMPILATION)
+#error "Only <snapd-glib/snapd-glib.h> can be included directly."
+#endif
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define SNAPD_TYPE_TASK_DATA  (snapd_task_data_get_type ())
+
+G_DECLARE_FINAL_TYPE (SnapdTaskData, snapd_task_data, SNAPD, TASK_DATA, GObject)
+
+GPtrArray *snapd_task_data_get_affected_snaps              (SnapdTaskData *task_data);
+
+G_END_DECLS
+
+#endif /* __SNAPD_TASK_DATA_H__ */

--- a/snapd-glib/snapd-task.c
+++ b/snapd-glib/snapd-task.c
@@ -337,7 +337,8 @@ snapd_task_set_property (GObject *object, guint prop_id, const GValue *value, GP
         break;
     case PROP_DATA:
         g_clear_object (&self->data);
-        self->data = g_object_ref (g_value_get_object (value));
+        if (g_value_get_object (value) != NULL)
+            self->data = g_object_ref (g_value_get_object (value));
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
@@ -487,7 +488,7 @@ snapd_task_class_init (SnapdTaskClass *klass)
                                                          G_TYPE_DATE_TIME,
                                                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
     g_object_class_install_property (gobject_class,
-                                     PROP_KIND,
+                                     PROP_DATA,
                                      g_param_spec_object ("data",
                                                           "data",
                                                           "Extra data of task",

--- a/snapd-glib/snapd-task.c
+++ b/snapd-glib/snapd-task.c
@@ -279,7 +279,7 @@ snapd_task_get_ready_time (SnapdTask *self)
  *
  * Get the extra data associated with the progress.
  *
- * Returns: (transfer full) (allow-none): a #SnapdTaskData or NULL.
+ * Returns: (transfer none) (allow-none): a #SnapdTaskData or NULL.
  *
  * Since: 1.66
  */

--- a/snapd-glib/snapd-task.c
+++ b/snapd-glib/snapd-task.c
@@ -41,6 +41,7 @@ struct _SnapdTask
     gint64 progress_total;
     GDateTime *spawn_time;
     GDateTime *ready_time;
+    SnapdTaskData *data;
 };
 
 enum
@@ -55,6 +56,7 @@ enum
     PROP_SPAWN_TIME,
     PROP_READY_TIME,
     PROP_PROGRESS_LABEL,
+    PROP_DATA,
     PROP_LAST
 };
 
@@ -271,6 +273,23 @@ snapd_task_get_ready_time (SnapdTask *self)
     return self->ready_time;
 }
 
+/**
+ * snapd_task_get_data:
+ * @task: a #SnapdTask.
+ *
+ * Get the extra data associated with the progress.
+ *
+ * Returns: (transfer full) (allow-none): a #SnapdTaskData or NULL.
+ *
+ * Since: 1.66
+ */
+SnapdTaskData *
+snapd_task_get_data (SnapdTask *self)
+{
+    g_return_val_if_fail (SNAPD_IS_TASK (self), NULL);
+    return self->data;
+}
+
 static void
 snapd_task_set_property (GObject *object, guint prop_id, const GValue *value, GParamSpec *pspec)
 {
@@ -316,6 +335,10 @@ snapd_task_set_property (GObject *object, guint prop_id, const GValue *value, GP
         if (g_value_get_boxed (value) != NULL)
             self->ready_time = g_date_time_ref (g_value_get_boxed (value));
         break;
+    case PROP_DATA:
+        g_clear_object (&self->data);
+        self->data = g_object_ref (g_value_get_object (value));
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
         break;
@@ -358,6 +381,9 @@ snapd_task_get_property (GObject *object, guint prop_id, GValue *value, GParamSp
     case PROP_READY_TIME:
         g_value_set_boxed (value, self->ready_time);
         break;
+    case PROP_DATA:
+        g_value_set_object (value, self->data);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
         break;
@@ -376,6 +402,7 @@ snapd_task_finalize (GObject *object)
     g_clear_pointer (&self->progress_label, g_free);
     g_clear_pointer (&self->spawn_time, g_date_time_unref);
     g_clear_pointer (&self->ready_time, g_date_time_unref);
+    g_clear_object (&self->data);
 
     G_OBJECT_CLASS (snapd_task_parent_class)->finalize (object);
 }
@@ -459,6 +486,13 @@ snapd_task_class_init (SnapdTaskClass *klass)
                                                          "Time this task completed",
                                                          G_TYPE_DATE_TIME,
                                                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
+    g_object_class_install_property (gobject_class,
+                                     PROP_KIND,
+                                     g_param_spec_object ("data",
+                                                          "data",
+                                                          "Extra data of task",
+                                                          SNAPD_TYPE_TASK_DATA,
+                                                          G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
 }
 
 static void

--- a/snapd-glib/snapd-task.h
+++ b/snapd-glib/snapd-task.h
@@ -15,6 +15,7 @@
 #endif
 
 #include <glib-object.h>
+#include "snapd-task-data.h"
 
 G_BEGIN_DECLS
 
@@ -42,6 +43,8 @@ gint64       snapd_task_get_progress_total (SnapdTask *task);
 GDateTime   *snapd_task_get_spawn_time     (SnapdTask *task);
 
 GDateTime   *snapd_task_get_ready_time     (SnapdTask *task);
+
+SnapdTaskData *snapd_task_get_data         (SnapdTask *task);
 
 G_END_DECLS
 

--- a/snapd-qt/Snapd/TaskData
+++ b/snapd-qt/Snapd/TaskData
@@ -1,0 +1,1 @@
+#include <Snapd/task-data.h>

--- a/snapd-qt/Snapd/task-data.h
+++ b/snapd-qt/Snapd/task-data.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 Canonical Ltd.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2 or version 3 of the License.
+ * See http://www.gnu.org/copyleft/lgpl.html the full text of the license.
+ */
+
+#ifndef SNAPD_TASK_DATA_H
+#define SNAPD_TASK_DATA_H
+
+#include <QtCore/QObject>
+#include <QtCore/QStringList>
+#include <Snapd/WrappedObject>
+
+class Q_DECL_EXPORT QSnapdTaskData : public QSnapdWrappedObject
+{
+    Q_OBJECT
+
+    Q_PROPERTY(QStringList affectedSnaps READ affectedSnaps)
+
+public:
+    explicit QSnapdTaskData (void* snapd_object, QObject* parent = 0);
+
+    Q_INVOKABLE QStringList affectedSnaps () const;
+};
+
+#endif

--- a/snapd-qt/Snapd/task.h
+++ b/snapd-qt/Snapd/task.h
@@ -12,6 +12,7 @@
 
 #include <QtCore/QObject>
 #include <QtCore/QDateTime>
+#include <Snapd/task-data.h>
 #include <Snapd/WrappedObject>
 
 class Q_DECL_EXPORT QSnapdTask : public QSnapdWrappedObject
@@ -27,6 +28,7 @@ class Q_DECL_EXPORT QSnapdTask : public QSnapdWrappedObject
     Q_PROPERTY(qint64 progressTotal READ progressTotal)
     Q_PROPERTY(QDateTime spawnTime READ spawnTime)
     Q_PROPERTY(QDateTime readyTime READ readyTime)
+    Q_PROPERTY(QSnapdTaskData taskData READ taskData)
 
 public:
     explicit QSnapdTask (void* snapd_object, QObject* parent = 0);
@@ -40,6 +42,7 @@ public:
     Q_INVOKABLE qint64 progressTotal () const;
     Q_INVOKABLE QDateTime spawnTime () const;
     Q_INVOKABLE QDateTime readyTime () const;
+    Q_INVOKABLE QSnapdTaskData *taskData() const;
 };
 
 #endif

--- a/snapd-qt/meson.build
+++ b/snapd-qt/meson.build
@@ -75,6 +75,7 @@ source_cpp = [
   'stream-wrapper.cpp',
   'system-information.cpp',
   'task.cpp',
+  'task-data.cpp',
   'user-information.cpp',
 ]
 
@@ -109,6 +110,7 @@ source_h = [
   'Snapd/snap.h',
   'Snapd/system-information.h',
   'Snapd/task.h',
+  'Snapd/task-data.h',
   'Snapd/user-information.h',
   'Snapd/wrapped-object.h',
 ]
@@ -142,6 +144,7 @@ source_alias_h = [
   'Snapd/Snap',
   'Snapd/SystemInformation',
   'Snapd/Task',
+  'Snapd/TaskData',
   'Snapd/UserInformation',
   'Snapd/WrappedObject',
 ]

--- a/snapd-qt/task-data.cpp
+++ b/snapd-qt/task-data.cpp
@@ -16,10 +16,10 @@ QSnapdTaskData::QSnapdTaskData (void *snapd_object, QObject *parent) : QSnapdWra
 QStringList QSnapdTaskData::affectedSnaps () const
 {
     QStringList retval;
-    GPtrArray *data = snapd_task_data_get_affected_snaps (SNAPD_TASK_DATA (wrapped_object));
+    GStrv data = snapd_task_data_get_affected_snaps (SNAPD_TASK_DATA (wrapped_object));
 
     if (data != NULL)
-        for (gsize i=0; i < data->len; i++)
-            retval.append((gchar *) data->pdata[i]);
+        for (; *data != NULL; data++)
+            retval.append((gchar *) *data);
     return retval;
 }

--- a/snapd-qt/task-data.cpp
+++ b/snapd-qt/task-data.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2024 Canonical Ltd.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2 or version 3 of the License.
+ * See http://www.gnu.org/copyleft/lgpl.html the full text of the license.
+ */
+
+#include <snapd-glib/snapd-glib.h>
+
+#include "Snapd/task-data.h"
+
+QSnapdTaskData::QSnapdTaskData (void *snapd_object, QObject *parent) : QSnapdWrappedObject (g_object_ref (snapd_object), g_object_unref, parent) {}
+
+QStringList QSnapdTaskData::affectedSnaps () const
+{
+    QStringList retval;
+    GPtrArray *data = snapd_task_data_get_affected_snaps (SNAPD_TASK_DATA (wrapped_object));
+
+    if (data != NULL)
+        for (gsize i=0; i < data->len; i++)
+            retval.append((gchar *) data->pdata[i]);
+    return retval;
+}

--- a/snapd-qt/task.cpp
+++ b/snapd-qt/task.cpp
@@ -72,3 +72,11 @@ QDateTime QSnapdTask::readyTime () const
 {
     return convertDateTime (snapd_task_get_ready_time (SNAPD_TASK (wrapped_object)));
 }
+
+QSnapdTaskData *QSnapdTask::taskData () const
+{
+    SnapdTaskData *data = SNAPD_TASK_DATA(snapd_task_get_data (SNAPD_TASK (wrapped_object)));
+    if (data == NULL)
+        return NULL;
+    return new QSnapdTaskData (SNAPD_TASK_DATA (data), NULL);
+}

--- a/tests/mock-snapd.h
+++ b/tests/mock-snapd.h
@@ -171,6 +171,9 @@ void            mock_task_set_spawn_time          (MockTask      *task,
 void            mock_task_set_ready_time          (MockTask      *task,
                                                    const gchar   *ready_time);
 
+void            mock_task_add_affected_snap       (MockTask      *task,
+                                                   const gchar *snap);
+
 void            mock_change_set_spawn_time        (MockChange    *change,
                                                    const gchar   *spawn_time);
 

--- a/tests/test-glib.c
+++ b/tests/test-glib.c
@@ -8925,7 +8925,7 @@ test_task_data_field (void)
     mock_task_add_affected_snap (task1, "cups");
     MockTask *task2 = mock_change_add_task (change, "task2");
     mock_task_add_affected_snap (task2, "cups");
-    MockTask *task3 = mock_change_add_task (change, "task3");
+    mock_change_add_task (change, "task3");
 
     g_autoptr(SnapdClient) client = snapd_client_new ();
     snapd_client_set_socket_path (client, mock_snapd_get_socket_path (snapd));
@@ -8947,18 +8947,18 @@ test_task_data_field (void)
 
     SnapdTaskData *data1 = snapd_task_get_data(task_1);
     g_assert_nonnull (data1);
-    GPtrArray *affected_snaps1 = snapd_task_data_get_affected_snaps(data1);
+    GStrv affected_snaps1 = snapd_task_data_get_affected_snaps(data1);
     g_assert_nonnull(affected_snaps1);
-    g_assert_cmpint(affected_snaps1->len, ==, 2);
-    g_assert_true(g_str_equal(affected_snaps1->pdata[0], "telegram-desktop"));
-    g_assert_true(g_str_equal(affected_snaps1->pdata[1], "cups"));
+    g_assert_cmpint(g_strv_length(affected_snaps1), ==, 2);
+    g_assert_true(g_str_equal(affected_snaps1[0], "telegram-desktop"));
+    g_assert_true(g_str_equal(affected_snaps1[1], "cups"));
 
     SnapdTaskData *data2 = snapd_task_get_data(task_2);
     g_assert_nonnull (data2);
-    GPtrArray *affected_snaps2 = snapd_task_data_get_affected_snaps(data2);
+    GStrv affected_snaps2 = snapd_task_data_get_affected_snaps(data2);
     g_assert_nonnull(affected_snaps2);
-    g_assert_cmpint(affected_snaps2->len, ==, 1);
-    g_assert_true(g_str_equal(affected_snaps2->pdata[0], "cups"));
+    g_assert_cmpint(g_strv_length(affected_snaps2), ==, 1);
+    g_assert_true(g_str_equal(affected_snaps2[0], "cups"));
 
     SnapdTaskData *data3 = snapd_task_get_data(task_3);
     g_assert_null (data3);
@@ -8968,6 +8968,7 @@ int
 main (int argc, char **argv)
 {
     g_test_init (&argc, &argv, NULL);
+
     g_test_add_func ("/notices/test_task_data_field", test_task_data_field);
     g_test_add_func ("/errors/test_error_get_change", test_error_get_change);
     g_test_add_func ("/notices/test_notices", test_notices_events);

--- a/tests/test-glib.c
+++ b/tests/test-glib.c
@@ -8911,10 +8911,64 @@ test_error_get_change (void)
     g_assert_nonnull (error);
 }
 
+static void
+test_task_data_field (void)
+{
+    g_autoptr(MockSnapd) snapd = mock_snapd_new ();
+
+    g_autoptr(GError) error = NULL;
+    g_assert_true (mock_snapd_start (snapd, &error));
+
+    MockChange *change = mock_snapd_add_change (snapd);
+    MockTask *task1 = mock_change_add_task (change, "task1");
+    mock_task_add_affected_snap (task1, "telegram-desktop");
+    mock_task_add_affected_snap (task1, "cups");
+    MockTask *task2 = mock_change_add_task (change, "task2");
+    mock_task_add_affected_snap (task2, "cups");
+    MockTask *task3 = mock_change_add_task (change, "task3");
+
+    g_autoptr(SnapdClient) client = snapd_client_new ();
+    snapd_client_set_socket_path (client, mock_snapd_get_socket_path (snapd));
+
+    g_autoptr(SnapdChange) change1 = snapd_client_get_change_sync (client, mock_change_get_id(change), NULL, &error);
+    g_assert_nonnull (change1);
+    g_assert_null (error);
+
+    GPtrArray *tasks = snapd_change_get_tasks(change1);
+    g_assert_nonnull(tasks);
+    g_assert_cmpint(tasks->len, ==, 3);
+
+    SnapdTask *task_1 = tasks->pdata[0];
+    g_assert_nonnull (task_1);
+    SnapdTask *task_2 = tasks->pdata[1];
+    g_assert_nonnull (task_2);
+    SnapdTask *task_3 = tasks->pdata[2];
+    g_assert_nonnull (task_3);
+
+    SnapdTaskData *data1 = snapd_task_get_data(task_1);
+    g_assert_nonnull (data1);
+    GPtrArray *affected_snaps1 = snapd_task_data_get_affected_snaps(data1);
+    g_assert_nonnull(affected_snaps1);
+    g_assert_cmpint(affected_snaps1->len, ==, 2);
+    g_assert_true(g_str_equal(affected_snaps1->pdata[0], "telegram-desktop"));
+    g_assert_true(g_str_equal(affected_snaps1->pdata[1], "cups"));
+
+    SnapdTaskData *data2 = snapd_task_get_data(task_2);
+    g_assert_nonnull (data2);
+    GPtrArray *affected_snaps2 = snapd_task_data_get_affected_snaps(data2);
+    g_assert_nonnull(affected_snaps2);
+    g_assert_cmpint(affected_snaps2->len, ==, 1);
+    g_assert_true(g_str_equal(affected_snaps2->pdata[0], "cups"));
+
+    SnapdTaskData *data3 = snapd_task_get_data(task_3);
+    g_assert_null (data3);
+}
+
 int
 main (int argc, char **argv)
 {
     g_test_init (&argc, &argv, NULL);
+    g_test_add_func ("/notices/test_task_data_field", test_task_data_field);
     g_test_add_func ("/errors/test_error_get_change", test_error_get_change);
     g_test_add_func ("/notices/test_notices", test_notices_events);
     g_test_add_func ("/notices/test_minimal_data", test_notices_events_with_minimal_data);

--- a/tests/test-qt.cpp
+++ b/tests/test-qt.cpp
@@ -7468,6 +7468,7 @@ int
 main (int argc, char **argv)
 {
     g_test_init (&argc, &argv, NULL);
+
     g_test_add_func ("/task/test_task_data_field", test_task_data_field);
     g_test_add_func ("/notices/test_notices", test_notices_events);
     g_test_add_func ("/notices/test_get_notices_after_notice", test_get_notices_after_notice);


### PR DESCRIPTION
This "data" field can contain several info, like the list of snaps that are affected by this task. Implemented in https://github.com/snapcore/snapd/pull/13953